### PR TITLE
Feature/vector search

### DIFF
--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -37,6 +37,7 @@ from api.schemas.responses import (
     PaginatedResponse,
 )
 from api.services.elasticsearch_service import elasticsearch_service
+from api.services.vector_search_service import vector_search_service
 from api.services.graph_service import graph_service
 from api.services.model_service import model_service
 from api.services.ro_crate_service import ro_crate_service
@@ -212,6 +213,66 @@ async def search_models_with_facets(
         raise HTTPException(status_code=400, detail=f"Invalid JSON format: {str(je)}")
     except Exception as e:
         logger.error(f"Error in faceted search: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Search error: {str(e)}")
+
+
+@router.get("/models/search_with_vector")
+async def search_models_with_vector(
+    query: str = Query("", description="Semantic search query (encoded to vector)"),
+    filters: str = Query(
+        "{}",
+        description="JSON string of property filters (e.g., {'license': ['MIT'], 'mlTask': ['text-generation']})",
+        examples=['{"license": ["MIT"], "mlTask": ["text-generation"]}'],
+    ),
+    page: int = Query(1, ge=1, description="Page number (1-based)"),
+    limit: int = Query(50, ge=1, le=1000, description="Results per page (max 1000)"),
+    facets: str = Query(
+        '["mlTask", "license", "keywords", "datasets", "platform"]',
+        description="JSON array of facet field names to aggregate",
+        examples=['["mlTask", "license", "keywords"]'],
+    ),
+    facet_size: int = Query(20, ge=1, le=100, description="Maximum values per facet (max 100)"),
+    facet_query: str = Query(
+        "{}",
+        description="JSON object for searching within specific facets (e.g., {'keywords': 'medical'})",
+        examples=['{"keywords": "medical"}'],
+    ),
+) -> Dict[str, Any]:
+    """
+    Vector-based semantic search using `model_vector` cosine similarity.
+
+    This mirrors the `/models/search_with_vector` endpoint from `mlentory_backend`.
+    """
+    try:
+        filter_dict = json.loads(filters) if filters else {}
+        facets_list = json.loads(facets) if facets else ["mlTask", "license", "keywords", "datasets", "platform"]
+        facet_query_dict = json.loads(facet_query) if facet_query else {}
+
+        if not isinstance(filter_dict, dict):
+            raise ValueError("Filters must be a JSON object/dictionary")
+        if not isinstance(facets_list, list):
+            raise ValueError("Facets must be a JSON array/list")
+        if not isinstance(facet_query_dict, dict):
+            raise ValueError("Facet query must be a JSON object/dictionary")
+        for key, values in filter_dict.items():
+            if not isinstance(values, list):
+                raise ValueError(f"Filter values for '{key}' must be a list")
+
+        return vector_search_service.vector_search(
+            query=query,
+            filters=filter_dict,
+            limit=limit,
+            page=page,
+            facets=facets_list,
+            facet_size=facet_size,
+            facet_query=facet_query_dict,
+        )
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except json.JSONDecodeError as je:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON format: {str(je)}")
+    except Exception as e:
+        logger.error("Error in vector search: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail=f"Search error: {str(e)}")
 
 

--- a/api/services/vector_search_service.py
+++ b/api/services/vector_search_service.py
@@ -1,0 +1,192 @@
+"""
+Vector search service for MLentory API.
+
+Mirrors the behavior of mlentory_backend's /models/search_with_vector endpoint:
+- encodes the user query into a vector embedding
+- runs cosine similarity against the indexed `model_vector` dense_vector field
+- supports filters + facet aggregations
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from api.config import get_es_client, get_es_config
+from api.services.faceted_search import FacetedSearchMixin
+
+logger = logging.getLogger(__name__)
+
+try:
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover
+    SentenceTransformer = None
+
+
+class _Embedder:
+    def __init__(self, model_name: str) -> None:
+        if SentenceTransformer is None:
+            raise RuntimeError("sentence-transformers is not available")
+        self._model_name = model_name
+        self._model: Optional[Any] = None
+        self._cache: Dict[str, List[float]] = {}
+
+    def _load(self) -> Any:
+        if self._model is None:
+            token = os.getenv("HUGGINGFACE_HUB_TOKEN") or os.getenv("HF_TOKEN")
+            self._model = SentenceTransformer(
+                self._model_name,
+                trust_remote_code=True,
+                token=token if token else None,
+            )
+        return self._model
+
+    def encode(self, text: str) -> List[float]:
+        key = (text or "").strip()
+        if key in self._cache:
+            return self._cache[key]
+        model = self._load()
+        emb = model.encode([key], show_progress_bar=False, normalize_embeddings=False)[0]
+        vec = emb.tolist()
+        self._cache[key] = vec
+        return vec
+
+
+_EMBEDDER: Optional[_Embedder] = None
+
+
+def _get_embedder() -> _Embedder:
+    global _EMBEDDER
+    if _EMBEDDER is None:
+        model_name = os.getenv(
+            "VECTOR_SEARCH_EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2"
+        )
+        _EMBEDDER = _Embedder(model_name=model_name)
+    return _EMBEDDER
+
+
+class VectorSearchService(FacetedSearchMixin):
+    """
+    Vector search service that queries Elasticsearch using cosine similarity against `model_vector`.
+    """
+
+    def __init__(self) -> None:
+        self.client = get_es_client()
+        self.config = get_es_config()
+
+    def vector_search(
+        self,
+        *,
+        query: str = "",
+        filters: Optional[Dict[str, List[str]]] = None,
+        limit: int = 50,
+        page: int = 1,
+        facets: Optional[List[str]] = None,
+        facet_size: int = 20,
+        facet_query: Optional[Dict[str, str]] = None,
+        indices: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        if SentenceTransformer is None:
+            return {
+                "models": [],
+                "total": 0,
+                "page": page,
+                "limit": limit,
+                "facets": {},
+                "facet_config": {},
+                "error": "sentence-transformers not installed in API container",
+            }
+
+        filters = filters or {}
+        facet_query = facet_query or {}
+        if facets is None:
+            facets = ["mlTask", "license", "keywords", "datasets", "platform"]
+
+        # default to the API's HF index unless explicitly overridden
+        indices = indices or [self.config.hf_models_index]
+
+        # pagination
+        limit = min(max(limit, 1), 1000)
+        page = max(page, 1)
+        offset = (page - 1) * limit
+
+        # encode query
+        query_vector = _get_embedder().encode(query or "")
+
+        # base query: only docs that actually have vectors
+        must_conditions: List[Dict[str, Any]] = [{"exists": {"field": "model_vector"}}]
+        must_conditions.extend(self._build_filter_conditions(filters))
+
+        base_query: Dict[str, Any] = {"bool": {"must": must_conditions}} if must_conditions else {"match_all": {}}
+
+        aggs = self._build_facet_aggregations(facets, facet_size, facet_query)
+        facet_config = self.get_facets_config()
+
+        body: Dict[str, Any] = {
+            "from": offset,
+            "size": limit,
+            "track_total_hits": True,
+            "query": {
+                "script_score": {
+                    "query": base_query,
+                    "script": {
+                        "source": "cosineSimilarity(params.query_vector, 'model_vector') + 1.0",
+                        "params": {"query_vector": query_vector},
+                    },
+                }
+            },
+            "aggs": aggs,
+            "_source": [
+                "name",
+                "description",
+                "ml_tasks",
+                "keywords",
+                "platform",
+                "db_identifier",
+                "shared_by",
+                "license",
+                "datasets",
+                "searchable_text",
+            ],
+        }
+
+        logger.info("Vector search: indices=%s page=%s limit=%s", indices, page, limit)
+        resp = self.client.search(
+            index=indices,
+            body=body,
+            params={"ignore_unavailable": "true"},
+            request_timeout=60,
+        )
+
+        hits = (resp.get("hits") or {}).get("hits", []) or []
+        total_raw = (resp.get("hits") or {}).get("total", 0)
+        total = int(total_raw.get("value", 0) if isinstance(total_raw, dict) else total_raw)
+
+        models: List[Dict[str, Any]] = []
+        for hit in hits:
+            src = hit.get("_source", {}) or {}
+            raw_score = float(hit.get("_score") or 0.0)  # cosineSimilarity+1 ∈ [0,2]
+            src["score"] = raw_score / 2.0
+            models.append(src)
+
+        facet_results: Dict[str, List[Dict[str, Any]]] = {}
+        aggs_data = resp.get("aggregations") or {}
+        for facet in facets:
+            key = f"{facet}_facet"
+            buckets = (aggs_data.get(key) or {}).get("buckets") or []
+            facet_results[facet] = [{"value": str(b.get("key")), "count": int(b.get("doc_count", 0))} for b in buckets]
+
+        return {
+            "query": query,
+            "page": page,
+            "limit": limit,
+            "models": models,
+            "total": total,
+            "facets": facet_results,
+            "facet_config": {k: v for k, v in facet_config.items() if k in facets},
+        }
+
+
+vector_search_service = VectorSearchService()
+

--- a/etl/assets/vector_indexing.py
+++ b/etl/assets/vector_indexing.py
@@ -1,0 +1,144 @@
+"""
+Dagster assets for vector embedding backfill into Elasticsearch.
+
+These assets do NOT create separate indices. They add dense-vector fields and
+embedding payloads directly onto existing model documents in the source index
+(e.g. ``hf_models`` / ``ai4life_models``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from dagster import AssetIn, asset
+
+from etl_loaders.vector_index_manager import run_vector_index_update
+
+logger = logging.getLogger(__name__)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default=%s", name, raw, default)
+        return default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def _write_report(report_path: Path, payload: Dict[str, Any]) -> str:
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(report_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+    return str(report_path)
+
+
+@asset(
+    group_name="vector_indexing",
+    ins={
+        "es_ready": AssetIn("hf_elasticsearch_ready"),
+        "indexed_report": AssetIn("hf_index_models_elasticsearch"),
+    },
+    tags={"pipeline": "hf_etl", "stage": "vector_index"},
+)
+def hf_vector_backfill(
+    es_ready: Dict[str, Any],
+    indexed_report: str,
+) -> str:
+    """Backfill vector fields into the HF Elasticsearch models index."""
+    index_name = es_ready.get("hf_models_index") or os.getenv("ELASTIC_HF_MODELS_INDEX", "hf_models")
+    batch_size = _env_int("VECTOR_INDEX_BATCH_SIZE", 50)
+    skip_existing = _env_bool("VECTOR_INDEX_SKIP_EXISTING", True)
+
+    logger.info(
+        "Running HF vector backfill: index=%s batch_size=%s skip_existing=%s",
+        index_name,
+        batch_size,
+        skip_existing,
+    )
+
+    stats = run_vector_index_update(
+        index_name=index_name,
+        es_ready=es_ready,
+        batch_size=batch_size,
+        skip_existing=skip_existing,
+        logger_instance=logger,
+    )
+
+
+    report_path: Optional[Path] = None
+    try:
+        report_path = Path(indexed_report).with_name("vector_index_report.json")
+    except Exception:
+        report_path = None
+
+    if not report_path:
+        report_path = Path("data") / "reports" / "hf" / "vector_index_report.json"
+
+    payload = {
+        "source_index_report": indexed_report,
+        **stats,
+    }
+    return _write_report(report_path, payload)
+
+
+@asset(
+    group_name="vector_indexing",
+    ins={
+        "es_ready": AssetIn("ai4life_elasticsearch_ready"),
+        "indexed_report": AssetIn("ai4life_index_models_elasticsearch"),
+    },
+    tags={"pipeline": "ai4life_etl", "stage": "vector_index"},
+)
+def ai4life_vector_backfill(
+    es_ready: Dict[str, Any],
+    indexed_report: str,
+) -> str:
+    """Backfill vector fields into the AI4Life Elasticsearch models index."""
+    index_name = es_ready.get("ai4life_models_index") or os.getenv("ELASTIC_AI4LIFE_MODELS_INDEX", "ai4life_models")
+    batch_size = _env_int("VECTOR_INDEX_BATCH_SIZE", 50)
+    skip_existing = _env_bool("VECTOR_INDEX_SKIP_EXISTING", True)
+
+    logger.info(
+        "Running AI4Life vector backfill: index=%s batch_size=%s skip_existing=%s",
+        index_name,
+        batch_size,
+        skip_existing,
+    )
+
+    stats = run_vector_index_update(
+        index_name=index_name,
+        es_ready=es_ready,
+        batch_size=batch_size,
+        skip_existing=skip_existing,
+        logger_instance=logger,
+    )
+
+    report_path: Optional[Path] = None
+    try:
+        report_path = Path(indexed_report).with_name("vector_index_report.json")
+    except Exception:
+        report_path = None
+
+    if not report_path:
+        report_path = Path("data") / "reports" / "ai4life" / "vector_index_report.json"
+
+    payload = {
+        "source_index_report": indexed_report,
+        **stats,
+    }
+    return _write_report(report_path, payload)
+

--- a/etl/repository.py
+++ b/etl/repository.py
@@ -12,6 +12,7 @@ from etl.assets import hf_loading as hf_loading_module
 from etl.assets import openml_extraction as openml_assets_module
 from etl.assets import ai4life_extraction as ai4life_assets_module
 from etl.assets import ai4life_transformation as ai4life_transformation_module
+from etl.assets import vector_indexing as vector_indexing_module
 
 @repository
 def mlentory_etl_repository():
@@ -27,5 +28,14 @@ def mlentory_etl_repository():
     openml_assets = load_assets_from_modules([openml_assets_module])
     ai4life_assets = load_assets_from_modules([ai4life_assets_module])
     ai4life_transformation_assets = load_assets_from_modules([ai4life_transformation_module])
-    return [*hf_extraction_assets, *hf_transformation_assets, *hf_loading_assets, *openml_assets, *ai4life_assets, *ai4life_transformation_assets]
+    vector_indexing_assets = load_assets_from_modules([vector_indexing_module])
+    return [
+        *hf_extraction_assets,
+        *hf_transformation_assets,
+        *hf_loading_assets,
+        *openml_assets,
+        *ai4life_assets,
+        *ai4life_transformation_assets,
+        *vector_indexing_assets,
+    ]
 

--- a/etl_loaders/vector_index_manager.py
+++ b/etl_loaders/vector_index_manager.py
@@ -1,0 +1,608 @@
+"""
+Vector Index Manager for ETL Backend.
+
+This module provides functionality to add vector embeddings to existing Elasticsearch indices.
+Vectors are appended as additional columns to pre-existing indices per data source (HF, OpenML, AI4Life).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import logging
+from typing import Dict, Any, List, Optional
+
+try:
+    from sentence_transformers import SentenceTransformer
+    from huggingface_hub import login
+except ImportError:
+    SentenceTransformer = None
+    login = None
+
+from etl_loaders.elasticsearch_store import ElasticsearchConfig, create_elasticsearch_client
+
+logger = logging.getLogger(__name__)
+
+
+class VectorIndexManager:
+    """
+    Manager for adding vector embeddings to existing Elasticsearch indices.
+    
+    This class handles:
+    - Adding vector field mappings to existing indices
+    - Generating embeddings for models using integrated embedding model
+    - Updating documents in-place with vector fields
+    
+    The embedding model is initialized directly in this class (no external dependency).
+    """
+    
+    # Default embedding configuration
+    DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-mpnet-base-v2"
+    DEFAULT_EMBEDDING_DIMENSION = 768  # MPNet default
+    DEFAULT_MAX_SEQUENCE_LENGTH = 512
+    
+    def __init__(self, es_client, index_name: str, logger_instance=None):
+        """
+        Initialize the vector index manager.
+        
+        Args:
+            es_client: Elasticsearch client instance
+            index_name: Name of the Elasticsearch index to update
+            logger_instance: Optional logger instance
+        """
+        self.es = es_client
+        self.index_name = index_name
+        self.logger = logger_instance or logger
+        
+        # Initialize embedding model directly
+        self.model = None
+        self.embedding_model = self.DEFAULT_EMBEDDING_MODEL
+        self.embedding_dimension = self.DEFAULT_EMBEDDING_DIMENSION
+        self.max_sequence_length = self.DEFAULT_MAX_SEQUENCE_LENGTH
+        self.device = self._resolve_device()
+        self._load_embedding_model()
+    
+    def _resolve_device(self) -> str:
+        """Resolve the device to use for embeddings (CUDA if available, else CPU)."""
+        try:
+            import torch
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        except Exception:
+            return "cpu"
+    
+    def _load_embedding_model(self):
+        """Load the sentence transformer model for generating embeddings."""
+        if not SentenceTransformer:
+            self.logger.warning("sentence-transformers not available. Vector indexing disabled.")
+            return
+        
+        # Authenticate with HuggingFace if token is provided
+        self._authenticate_huggingface()
+        
+        # Set PyTorch environment variables
+        os.environ['TOKENIZERS_PARALLELISM'] = 'false'
+        os.environ['PYTORCH_CUDA_ALLOC_CONF'] = 'max_split_size_mb:128'
+        
+        try:
+            start_time = time.time()
+            token = os.getenv('HUGGINGFACE_HUB_TOKEN') or os.getenv('HF_TOKEN')
+            
+            # Load the model
+            try:
+                # Handle special cases for certain models
+                if "google/embeddinggemma" in self.embedding_model:
+                    import torch
+                    os.environ['PYTORCH_CUDA_ALLOC_CONF'] = 'max_split_size_mb:128'
+                    torch.backends.cudnn.enabled = False
+                
+                self.model = SentenceTransformer(
+                    self.embedding_model,
+                    device=self.device,
+                    trust_remote_code=True,
+                    token=token if token else None
+                )
+            except Exception as meta_error:
+                if "meta tensor" in str(meta_error).lower():
+                    self.logger.warning("Meta tensor issue detected, trying alternative loading method...")
+                    import torch
+                    torch.backends.cudnn.enabled = False
+                    self.model = SentenceTransformer(
+                        self.embedding_model,
+                        device=self.device,
+                        trust_remote_code=True,
+                        use_auth_token=False
+                    )
+                else:
+                    raise meta_error
+            
+            load_time = time.time() - start_time
+            
+            # Validate the model
+            self._validate_model()
+            
+            self.logger.info(f"Embedding model initialized: {self.embedding_model} (loaded in {load_time:.2f}s)")
+            
+        except Exception as e:
+            self.logger.warning(f"Failed to load embedding model {self.embedding_model}: {e}")
+            # Try minimal configuration as fallback
+            try:
+                self.logger.info("Retrying with minimal configuration...")
+                self.model = SentenceTransformer(self.embedding_model)
+                self._validate_model()
+                self.logger.info("Model loaded with minimal configuration")
+            except Exception as retry_error:
+                self.logger.error(f"Failed to load embedding model: {retry_error}")
+                self.model = None
+    
+    def _authenticate_huggingface(self):
+        """Authenticate with HuggingFace if token is available."""
+        if not login:
+            return
+        
+        if not hasattr(self, '_hf_authenticated'):
+            token = os.getenv('HUGGINGFACE_HUB_TOKEN') or os.getenv('HF_TOKEN')
+            if token:
+                try:
+                    login(token=token)
+                    self.logger.info("Authenticated with Hugging Face")
+                except Exception as e:
+                    self.logger.warning(f"Hugging Face authentication failed: {e}")
+            self._hf_authenticated = True
+    
+    def _validate_model(self):
+        """Validate that the loaded model works correctly."""
+        if not self.model:
+            return
+        
+        try:
+            # Test with a simple sentence
+            test_text = "This is a test sentence for validation"
+            test_embedding = self.model.encode(
+                [test_text],
+                show_progress_bar=False,
+                normalize_embeddings=False
+            )
+            
+            # Check dimensions
+            actual_dimension = len(test_embedding[0])
+            if actual_dimension != self.embedding_dimension:
+                self.logger.warning(
+                    f"Expected dimension {self.embedding_dimension}, "
+                    f"but got {actual_dimension}. Updating..."
+                )
+                self.embedding_dimension = actual_dimension
+        except Exception as e:
+            self.logger.error(f"Model validation failed: {e}")
+            raise
+    
+    def _clean_text(self, text: str) -> str:
+        """Clean and prepare text for embedding."""
+        if not text:
+            return ""
+        
+        # Basic cleaning
+        cleaned = text.strip()
+        
+        # Truncate if too long (models have limits)
+        if len(cleaned) > self.max_sequence_length:
+            cleaned = cleaned[:self.max_sequence_length]
+        
+        return cleaned
+    
+    def _encode_text(self, text: str) -> List[float]:
+        """
+        Encode text to vector using the loaded embedding model.
+        
+        Args:
+            text: Text to encode
+            
+        Returns:
+            List of floats representing the embedding vector
+        """
+        if not self.model:
+            return [0.0] * self.embedding_dimension
+        
+        if not text or not text.strip():
+            return [0.0] * self.embedding_dimension
+        
+        try:
+            # Clean and prepare the text
+            cleaned_text = self._clean_text(text)
+            
+            # Generate embedding
+            embedding = self.model.encode(
+                [cleaned_text],
+                show_progress_bar=False,
+                normalize_embeddings=False
+            )
+            vector = embedding[0].tolist()  # Convert numpy array to list
+            
+            return vector
+            
+        except Exception as e:
+            self.logger.error(f"Failed to encode text: {e}")
+            return [0.0] * self.embedding_dimension
+    
+    def initialize_vector_index(self) -> bool:
+        """
+        Add vector fields to the existing index mapping.
+        Updates the index mapping to include vector fields without creating a separate index.
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.model:
+            self.logger.warning("Embedding model not available, skipping vector field initialization")
+            return False
+        
+        try:
+            # Check if source index exists
+            if not self.es.indices.exists(index=self.index_name):
+                self.logger.error(f"Index {self.index_name} does not exist. Cannot add vector fields.")
+                return False
+            
+            # Check current mapping to see if vector fields already exist
+            current_mapping = self.es.indices.get_mapping(index=self.index_name)
+            properties = current_mapping[self.index_name]["mappings"].get("properties", {})
+            
+            # Check if vector fields already exist
+            if "model_vector" in properties:
+                self.logger.info(f"Vector fields already exist in {self.index_name}")
+                return True
+            
+            # Add vector fields to existing index mapping
+            vector_fields_mapping = {
+                "properties": {
+                    # Extracted fields from description (add if not present)
+                    "version": {"type": "keyword"},
+                    "modalities": {"type": "keyword"},
+                    "domain": {"type": "keyword"},
+                    "architecture": {"type": "text"},
+                    "modelSize": {"type": "keyword"},
+                    "dataset": {"type": "text"},
+                    "trainingType": {"type": "keyword"},
+                    
+                    # MPNet vector field
+                    "model_vector": {
+                        "type": "dense_vector",
+                        "dims": self.embedding_dimension,
+                        "index": True,
+                        "similarity": "cosine"
+                    },
+                    
+                    # Searchable text field
+                    "searchable_text": {"type": "text"},
+                    
+                    # Metadata fields
+                    "vector_created_at": {"type": "date"},
+                    "embedding_model": {"type": "keyword"}
+                }
+            }
+            
+            # Update the index mapping
+            self.es.indices.put_mapping(
+                index=self.index_name,
+                body=vector_fields_mapping
+            )
+            self.logger.info(f"Added vector fields to index: {self.index_name}")
+            return True
+            
+        except Exception as e:
+            self.logger.error(f"Failed to add vector fields to index: {e}")
+            import traceback
+            traceback.print_exc()
+            return False
+    
+    def prepare_searchable_text(self, model_data: Dict[str, Any], extracted_data: Optional[Dict[str, Any]] = None) -> str:
+        """
+        Prepare structured searchable text from model data for embedding.
+        
+        This creates a structured text representation from available model fields.
+        
+        Args:
+            model_data: Dictionary containing model information from source index
+            extracted_data: Optional dictionary containing extracted fields from description
+            
+        Returns:
+            str: Structured text for embedding and storage
+        """
+        text_parts = []
+        extracted_data = extracted_data or {}
+        
+        # === ORIGINAL DATA FIELDS ===
+        
+        # Model name
+        name = model_data.get('name')
+        if name:
+            text_parts.append(f"The model name is {name}.")
+        
+        # Shared by
+        shared_by = model_data.get('sharedBy') or model_data.get('shared_by')
+        if shared_by:
+            text_parts.append(f"It is shared by {shared_by}.")
+        
+        # ML Task
+        ml_task = model_data.get('mlTask') or model_data.get('ml_task') or model_data.get('ml_tasks')
+        if ml_task:
+            if isinstance(ml_task, list):
+                ml_task_str = ', '.join(str(t) for t in ml_task if t)
+            else:
+                ml_task_str = str(ml_task)
+            text_parts.append(f"The model performs the {ml_task_str} task.")
+        
+        # Keywords
+        keywords = model_data.get('keywords')
+        if keywords and isinstance(keywords, list) and keywords:
+            keywords_str = ', '.join(str(k) for k in keywords if k)
+            text_parts.append(f"Keywords: {keywords_str}.")
+        
+        # Description
+        description = model_data.get('description')
+        if description:
+            # Truncate description if too long
+            desc_text = str(description)
+            if len(desc_text) > 500:
+                desc_text = desc_text[:500] + "..."
+            text_parts.append(f"Description: {desc_text}")
+        
+        # === EXTRACTED FIELDS (if available) ===
+        
+        # Version (extracted)
+        version = extracted_data.get('version')
+        if version:
+            text_parts.append(f"The version is {version}.")
+        
+        # Modalities (extracted)
+        modalities = extracted_data.get('modalities')
+        if modalities and isinstance(modalities, list) and modalities:
+            modalities_str = ', '.join(str(m) for m in modalities if m)
+            text_parts.append(f"The model works with {modalities_str} modalities.")
+        
+        # Domain (extracted)
+        domain = extracted_data.get('domain')
+        if domain:
+            text_parts.append(f"The domain of the model is {domain}.")
+        
+        # Training type (extracted)
+        training_type = extracted_data.get('trainingType') or extracted_data.get('training_type')
+        if training_type:
+            text_parts.append(f"The training type is {training_type}.")
+        
+        # Architecture (extracted)
+        architecture = extracted_data.get('architecture')
+        if architecture:
+            text_parts.append(f"The architecture is {architecture}.")
+        
+        # Model size (extracted)
+        model_size = extracted_data.get('modelSize') or extracted_data.get('model_size')
+        if model_size:
+            text_parts.append(f"The model size is {model_size}.")
+        
+        # Datasets
+        datasets = model_data.get('datasets') or model_data.get('dataset')
+        extracted_ds = extracted_data.get('dataset')
+        
+        combined_datasets = []
+        seen_lower = set()
+        
+        # From original field
+        if datasets:
+            if isinstance(datasets, list):
+                candidates = datasets
+            else:
+                candidates = [str(datasets)]
+            for ds in candidates:
+                if not ds:
+                    continue
+                ds_str = str(ds).strip()
+                if not ds_str or ds_str.lower() == 'information not found':
+                    continue
+                key = ds_str.lower()
+                if key not in seen_lower:
+                    seen_lower.add(key)
+                    combined_datasets.append(ds_str)
+        
+        # From extracted field
+        if extracted_ds:
+            ds_str = str(extracted_ds).strip()
+            if ds_str:
+                key = ds_str.lower()
+                if key not in seen_lower:
+                    seen_lower.add(key)
+                    combined_datasets.append(ds_str)
+        
+        if combined_datasets:
+            if len(combined_datasets) == 1:
+                text_parts.append(f"It was trained on the {combined_datasets[0]} dataset.")
+            else:
+                datasets_str = ', '.join(combined_datasets)
+                text_parts.append(f"It was trained on the {datasets_str} datasets.")
+        
+        # Join all parts
+        searchable_text = ' '.join(text_parts)
+        
+        return searchable_text
+    
+    def update_vector_index(
+        self, 
+        model_ids: Optional[List[str]] = None, 
+        batch_size: int = 50, 
+        skip_existing: bool = True
+    ) -> Dict[str, Any]:
+        """
+        Add vector fields to existing documents in the index.
+        Updates documents in-place by adding vector embeddings and extracted metadata.
+        
+        Args:
+            model_ids: Optional list of specific model IDs to update.
+                      If None, updates all models from index.
+            batch_size: Number of models to process in each batch
+            skip_existing: If True, skip documents that already have model_vector field
+            
+        Returns:
+            Dictionary with statistics about the update operation
+        """
+        if not self.model:
+            self.logger.warning("Embedding model not available")
+            return {"processed": 0, "errors": 0, "skipped": 0}
+        
+        try:
+            # Ensure vector index exists
+            if not self.initialize_vector_index():
+                return {"processed": 0, "errors": 0, "skipped": 0}
+            
+            # Get models to process
+            if model_ids:
+                # Process specific models
+                query = {"query": {"terms": {"_id": model_ids}}}
+            else:
+                # Process all models
+                query = {"query": {"match_all": {}}}
+            
+            # Use scroll API for large datasets
+            response = self.es.search(
+                index=self.index_name,
+                body=query,
+                scroll='5m',
+                size=batch_size,
+                _source=True
+            )
+            
+            scroll_id = response['_scroll_id']
+            hits = response['hits']['hits']
+            total_processed = 0
+            total_errors = 0
+            total_skipped = 0
+            
+            while hits:
+                self.logger.info(f"Processing batch of {len(hits)} models...")
+                
+                # Process batch
+                for hit in hits:
+                    model_data = hit["_source"]
+                    model_id = hit["_id"]
+                    
+                    # Skip if document already has vector fields and skip_existing is True
+                    if skip_existing and "model_vector" in model_data:
+                        total_skipped += 1
+                        continue
+                    
+                    try:
+                        # For now, we don't have metadata extraction in etl_backend
+                        # So we'll use empty extracted_data
+                        extracted_data = {}
+                        
+                        # Prepare searchable text using structured format
+                        searchable_text = self.prepare_searchable_text(model_data, extracted_data)
+                        
+                        if not searchable_text:
+                            self.logger.warning(f"Skipping model {model_id} - no searchable text")
+                            total_skipped += 1
+                            continue
+                        
+                        # Generate embedding using integrated model
+                        model_vector = self._encode_text(searchable_text)
+                        
+                        # Prepare update document with extracted fields, vector, and searchable text
+                        # Only update/add vector-related fields, keep existing document data intact
+                        update_doc = {
+                            **extracted_data,  # Extracted fields (empty for now)
+                            "model_vector": model_vector,
+                            "searchable_text": searchable_text,  # Store the text used for embedding
+                            "vector_created_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                            "embedding_model": self.embedding_model
+                        }
+                        
+                        # Update existing document in index with vector fields
+                        self.es.update(
+                            index=self.index_name,
+                            id=model_id,
+                            body={"doc": update_doc}
+                        )
+                        total_processed += 1
+                        
+                    except Exception as e:
+                        total_errors += 1
+                        self.logger.warning(f"Error processing model {model_id}: {e}")
+                        continue
+                
+                # Get next batch
+                response = self.es.scroll(scroll_id=scroll_id, scroll='5m')
+                scroll_id = response['_scroll_id']
+                hits = response['hits']['hits']
+                
+                self.logger.info(f"Processed {total_processed} models so far...")
+            
+            # Clear scroll and refresh
+            self.es.clear_scroll(scroll_id=scroll_id)
+            self.es.indices.refresh(index=self.index_name)
+            
+            self.logger.info(
+                f"Successfully processed {total_processed} models, "
+                f"skipped {total_skipped}, errors {total_errors} "
+                f"and added vector fields to {self.index_name}"
+            )
+            
+            return {
+                "processed": total_processed,
+                "skipped": total_skipped,
+                "errors": total_errors,
+                "index": self.index_name
+            }
+            
+        except Exception as e:
+            self.logger.error(f"Vector index update failed: {e}")
+            import traceback
+            traceback.print_exc()
+            return {"processed": 0, "errors": 1, "skipped": 0}
+
+
+def run_vector_index_update(
+    index_name: str,
+    *,
+    es_client=None,
+    es_config: Optional[ElasticsearchConfig] = None,
+    es_ready: Optional[Dict[str, Any]] = None,
+    model_ids: Optional[List[str]] = None,
+    batch_size: int = 50,
+    skip_existing: bool = True,
+    logger_instance=None,
+) -> Dict[str, Any]:
+    """
+    Run vector embedding backfill for an Elasticsearch index using VectorIndexManager.
+
+    Creates an ES client from config when ``es_client`` is not provided.
+    Used by Dagster assets and one-off scripts so pipeline code stays thin.
+    """
+    log = logger_instance or logger
+    cfg = es_config or ElasticsearchConfig.from_env()
+    client = es_client or create_elasticsearch_client(cfg)
+
+    if not client.indices.exists(index=index_name):
+        log.warning("Index %s does not exist. Skipping vector indexing.", index_name)
+        return {
+            "status": "skipped",
+            "reason": "index_not_found",
+            "index": index_name,
+            "processed": 0,
+            "skipped": 0,
+            "errors": 0,
+        }
+
+    manager = VectorIndexManager(es_client=client, index_name=index_name, logger_instance=log)
+    stats = manager.update_vector_index(
+        model_ids=model_ids,
+        batch_size=batch_size,
+        skip_existing=skip_existing,
+    )
+    result: Dict[str, Any] = {
+        "status": "success",
+        "index": index_name,
+        **stats,
+    }
+    if es_ready is not None:
+        cluster = es_ready.get("cluster_name")
+        if cluster is not None:
+            result["cluster_name"] = cluster
+    return result
+


### PR DESCRIPTION
## Summary
Added vector-based semantic search with the same request/response shape as `search` endpoint.

## What changed

- Added a Vector Search service that:
    - Encodes the incoming query using sentence-transformers/all-mpnet-base-v2 (configurable via env)
    - Queries Elasticsearch using script_score + cosineSimilarity against model_vector
    - Supports pagination, filters, and facet aggregations
    - Returns results with a normalized similarity score
- Added a new API endpoint:
    - GET `/api/v1/models/search_with_vector`
- Mirrors mlentory_backend’s /models/search_with_vector behavior so frontend/integrations can swap to ETL backend 