### PR TITLE
fix: add baseModels field to ModelListItem schema and constructors

### DIFF
--- a/api/schemas/responses.py
+++ b/api/schemas/responses.py
@@ -58,6 +58,7 @@ class ModelListItem(BaseModel):
     mlTask: List[str] = Field(description="Machine learning tasks", default_factory=list)
     keywords: List[str] = Field(description="Model keywords/tags", default_factory=list)
     datasets: List[str] = Field(description="Datasets the model was trained on", default_factory=list)
+    baseModels: List[str] = Field(description="Base model identifiers", default_factory=list)
     platform: str = Field(description="Platform where model is hosted (e.g., 'Hugging Face')")
 
 

--- a/api/services/elasticsearch_service.py
+++ b/api/services/elasticsearch_service.py
@@ -99,6 +99,7 @@ class ElasticsearchService(FacetedSearchMixin):
                 mlTask=hit.ml_tasks or [],  # Note: ES field is snake_case, but schema uses camelCase
                 keywords=hit.keywords or [],
                 datasets=getattr(hit, "datasets", None) or [],
+                baseModels=getattr(hit, "baseModels", []) or [],
                 platform=hit.platform or "Unknown",
             )
             models.append(model)
@@ -153,6 +154,7 @@ class ElasticsearchService(FacetedSearchMixin):
             mlTask=hit["ml_tasks"] or [],  # Note: ES field is snake_case, but schema uses camelCase
             keywords=hit["keywords"] or [],
             datasets=hit.get("datasets", []) or [],
+            baseModels=hit.get("baseModels", []),
             platform=hit.get("platform", "Unknown"),
         )
 

--- a/api/services/faceted_search.py
+++ b/api/services/faceted_search.py
@@ -375,6 +375,7 @@ class FacetedSearchMixin:
                     mlTask=source.get("ml_tasks", []),
                     keywords=source.get("keywords", []),
                     datasets=source.get("datasets", []) or [],
+                    baseModels=source.get("baseModels", []),
                     platform=source.get("platform", "Unknown"),
                 )
                 models.append(model)


### PR DESCRIPTION
ModelListItem in api/schemas/responses.py was missing the baseModels field, causing it to be silently dropped in API responses even though the Elasticsearch index correctly stores it and search_service.py maps it from ES hits.

## The bug

The data pipeline for `baseModels` was mostly complete:
- `ElasticsearchEntities.py` declares the field: `baseModels = Text(multi=True)`
- `IndexHandler.py` populates it from enrichment data
- `search_service.py` maps it from ES hits into raw dicts

But the main API response path goes through `ModelListItem`, which didn't have the field. So anything using the standard model list endpoint would never see baseModels.

## Changes

- Add `baseModels: List[str]` to `ModelListItem` Pydantic model in `api/schemas/responses.py`
- Map `baseModels` in `elasticsearch_service.py` — both the list view and `get_model_by_id` paths
- Map `baseModels` in `faceted_search.py` — the faceted search path

The LLM router (`api/routers/llm.py`) was not affected since it uses raw dicts, not the Pydantic model.

## Testing

- [ ] Verify baseModels appears in `GET /models` responses
- [ ] Verify baseModels appears in `GET /models/{id}` responses
- [ ] Verify baseModels appears in faceted search responses