### PR TITLE
Hybrid STELLA + ES pagination

### DIFF
--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -127,10 +127,14 @@ async def search_models_with_facets(
         examples=['["mlTask", "license", "keywords", "datasets"]'],
     ),
     facet_size: int = Query(20, ge=1, le=100, description="Maximum values per facet (max 100)"),
-    facet_query: str = Query(
+        facet_query: str = Query(
         '{}',
         description="JSON object for searching within specific facets (e.g., {'keywords': 'medical'})",
         examples=['{"keywords": "medical", "mlTask": "text"}'],
+    ),
+    exclude_ids: str = Query(
+        '[]',
+        description="JSON array of model identifiers to exclude (e.g. STELLA page-1 results on later pages)",
     ),
 ) -> FacetedSearchResponse:
     """
@@ -178,6 +182,7 @@ async def search_models_with_facets(
         filter_dict = json.loads(filters) if filters else {}
         facets_list = json.loads(facets) if facets else ["mlTask", "license", "keywords", "platform"]
         facet_query_dict = json.loads(facet_query) if facet_query else {}
+        exclude_id_list = json.loads(exclude_ids) if exclude_ids else []
 
         # Validate inputs
         if not isinstance(filter_dict, dict):
@@ -186,6 +191,8 @@ async def search_models_with_facets(
             raise ValueError("Facets must be a JSON array/list")
         if not isinstance(facet_query_dict, dict):
             raise ValueError("Facet query must be a JSON object/dictionary")
+        if not isinstance(exclude_id_list, list):
+            raise ValueError("exclude_ids must be a JSON array/list")
 
         for key, values in filter_dict.items():
             if not isinstance(values, list):
@@ -200,6 +207,7 @@ async def search_models_with_facets(
             facets=facets_list,
             facet_size=facet_size,
             facet_query=facet_query_dict,
+            exclude_ids=exclude_id_list,
         )
 
         # Get facet configuration for requested facets

--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -520,6 +520,7 @@ async def get_model_detail_with_metadata(
 
 # Specific routes MUST be defined before dynamic routes
 @router.get("/models/ro-crate")
+@router.get("/models/ro_crate")
 async def get_model_ro_crate(
     model_id: str = Query(..., description="Model ID (URI or compact ID)"),
 ) -> Dict[str, Any]:

--- a/api/services/faceted_search.py
+++ b/api/services/faceted_search.py
@@ -314,7 +314,8 @@ class FacetedSearchMixin:
         page_size: int = 50,
         facets: Optional[List[str]] = None,
         facet_size: int = 20,
-        facet_query: Optional[Dict[str, str]] = None
+        facet_query: Optional[Dict[str, str]] = None,
+        exclude_ids: Optional[List[str]] = None,
     ) -> Tuple[List[ModelListItem], int, Dict[str, List[FacetValue]]]:
         """
         Search for models with faceted navigation support.
@@ -337,7 +338,12 @@ class FacetedSearchMixin:
         """
         # Ensure page_size is within bounds
         page_size = min(max(page_size, 1), 1000)
-        from_offset = (page - 1) * page_size
+        # Page 1 may be served by STELLA; ES pages 2+ exclude those ids and continue
+        # from the start of the ES ranking (page 2 -> offset 0, page 3 -> offset RPP, ...).
+        if exclude_ids and page > 1:
+            from_offset = max(0, (page - 2) * page_size)
+        else:
+            from_offset = (page - 1) * page_size
 
         # Default facets if none specified
         if facets is None:
@@ -357,6 +363,12 @@ class FacetedSearchMixin:
         if filters:
             must_conditions.extend(self._build_filter_conditions(filters))
 
+        bool_query: Dict[str, Any] = {
+            "must": must_conditions if must_conditions else [{"match_all": {}}],
+        }
+        if exclude_ids:
+            bool_query["must_not"] = [{"terms": {"db_identifier": exclude_ids}}]
+
         # Build aggregations
         aggs = self._build_facet_aggregations(facets, facet_size, facet_query)
 
@@ -366,9 +378,7 @@ class FacetedSearchMixin:
             "size": page_size,
             "track_total_hits": True,
             "query": {
-                "bool": {
-                    "must": must_conditions if must_conditions else [{"match_all": {}}]
-                }
+                "bool": bool_query
             },
             "aggs": aggs,
             "_source": [


### PR DESCRIPTION
1. GET /api/v1/models/search accepts new query param exclude_ids (JSON array of model identifiers).
2. ES query
 - Add must_not: { terms: { db_identifier: exclude_ids } } } when exclude_ids is non-empty.
3. Offset when continuing after STELLA page 1
-  Normal: from = (page − 1) × page_size
-  With exclude_ids and page > 1: from = (page − 2) × page_size
- Page 1 is STELLA, so ES “page 2” starts at offset 0 in the filtered ES ranking; page 3 at offset page_size, etc.

4. Facets and track_total_hits behave as before; only hits and offset change.

Example flow:

```
Page 1 (STELLA):     [A, B, C, D, E]  → store ids {A..E}, total=100
Page 2 (ES):         exclude {A..E}, from=0  → [F, G, H, I, J]
Page 3 (ES):         exclude {A..E}, from=5  → [K, L, M, N, O]
```