### PR TITLE
kaggle extraction integration:  successful (50 models tested)

### DIFF
--- a/config/etl/run_config.yaml
+++ b/config/etl/run_config.yaml
@@ -53,3 +53,13 @@ platforms:
     # Parent ID for collection filtering
     parent_id: "bioimage-io/bioimage.io"
 
+   # Kaggle Configuration
+  kaggle:
+    
+    num_models: 50              # cap for testing; null = all
+    incremental: false
+    force_full_refresh: false
+    refresh_metadata: true
+    threads: 8
+   
+

--- a/config/etl/run_config.yaml
+++ b/config/etl/run_config.yaml
@@ -18,6 +18,7 @@ platforms:
   huggingface:
     # Number of latest models to extract
     num_models: 10
+    
     # Whether to prioritize recently updated models
     update_recent: true
     # Number of parallel threads for extraction
@@ -55,11 +56,10 @@ platforms:
 
    # Kaggle Configuration
   kaggle:
-    
-    num_models: 50              # cap for testing; null = all
+    num_models: null            # null = all (~43,044)
     incremental: false
     force_full_refresh: false
     refresh_metadata: true
-    threads: 8
+    threads: 4
    
 

--- a/etl/assets/kaggle_extraction.py
+++ b/etl/assets/kaggle_extraction.py
@@ -1,0 +1,204 @@
+"""
+Dagster assets for Kaggle model-card extraction.
+
+Pipeline:
+1) Create run folder: /data/1_raw/kaggle/<timestamp_uuid>/
+2) Build owner/slug refs from the Meta Kaggle dataset
+3) Fetch model cards from the Kaggle API (parallel, resumable, incremental)
+4) Normalize records and persist under the run folder
+
+Crawl state lives in /data/1_raw/kaggle/_state/ rather than the run folder:
+resume and incremental refresh both work by reading what previous runs
+collected, so a per-run location would reset them every time and turn every
+run into a fresh multi-hour crawl.
+"""
+
+import os  
+import json
+import logging
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple, List, Dict, Any, Set
+
+import pandas as pd
+from dagster import AssetIn, asset
+
+from etl.config import get_kaggle_config
+from etl_extractors.kaggle import KaggleExtractor
+from etl_extractors.kaggle.kaggle_crawler import KaggleCrawler
+from etl_extractors.kaggle.kaggle_helper import KaggleHelper
+from etl_extractors.kaggle.kaggle_enrichment import KaggleEnrichment
+
+logger = logging.getLogger(__name__)
+
+
+KAGGLE_ROOT = Path("/data/1_raw/kaggle")
+STATE_DIR = Path(os.getenv("CACHE_PATH", "/data/cache")) / "kaggle"
+
+
+@asset(group_name="kaggle_extraction", tags={"pipeline": "Kaggle_etl"})
+def kaggle_run_folder() -> str:
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    run_id = str(uuid.uuid4())[:8]
+    run_folder = KAGGLE_ROOT / f"{timestamp}_{run_id}"
+    run_folder.mkdir(parents=True, exist_ok=True)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    logger.info("Created Kaggle run folder: %s", run_folder)
+    return str(run_folder)
+
+@asset(
+    group_name="kaggle_extraction",
+    tags={"pipeline": "Kaggle_etl"},
+    ins={"run_folder": AssetIn("kaggle_run_folder")},
+)
+def kaggle_raw_catalog_sources(run_folder: str) -> str:
+    """
+    Write the canonical Kaggle catalog ``WebSite`` to the raw run folder.
+ 
+    Produces ``sources.json`` (one row) with ``mlentory_id`` and schema.org fields
+    so downstream transform/load can align ``MLModel.source`` with extraction.
+    """
+    out_path = Path(run_folder) / "sources.json"
+    payload = KaggleHelper.raw_kaggle_catalog_website_records()
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+    logger.info("Wrote Kaggle catalog sources to %s", out_path)
+    return str(out_path)
+ 
+
+
+@asset(group_name="kaggle_extraction", tags={"pipeline": "Kaggle_etl"}, ins={"run_folder": AssetIn("kaggle_run_folder")})
+def kaggle_model_refs(run_folder: str) -> List[str]:
+    """Build the owner/slug ref list from the Meta Kaggle dataset."""
+    config = get_kaggle_config()
+    crawler = KaggleCrawler(
+        output_dir=str(STATE_DIR),
+        threads=config.threads,
+        meta_dataset=config.meta_dataset,
+    )
+    crawler.check_credentials()
+
+    if config.refresh_metadata:
+        crawler.ensure_meta_kaggle_csvs(force=True)
+    refs = crawler.load_or_build_refs(rebuild=config.refresh_metadata)
+
+    logger.info("Built %d Kaggle model refs for run %s", len(refs), run_folder)
+    return refs
+
+
+@asset(group_name="kaggle_extraction", tags={"pipeline": "Kaggle_etl"}, ins={"run_folder": AssetIn("kaggle_run_folder"), "refs": AssetIn("kaggle_model_refs")})
+def kaggle_raw_records(run_folder: str, refs: List[str]) -> Dict[str, Any]:
+    """Fetch raw model cards from the Kaggle API and set extraction timestamp."""
+    config = get_kaggle_config()
+    extractor = KaggleExtractor()
+
+    records_data, extraction_timestamp = extractor.fetch_records(
+        output_dir=str(STATE_DIR),
+        num_models=config.num_models,
+        incremental=config.incremental,
+        force_full_refresh=config.force_full_refresh,
+        refresh_metadata=False,  # already refreshed by kaggle_model_refs
+        threads=config.threads,
+        max_retries=config.max_retries,
+        request_timeout_seconds=config.request_timeout_seconds,
+        checkpoint_every=config.checkpoint_every,
+        meta_dataset=config.meta_dataset,
+    )
+    
+    records_data["timestamp"] = extraction_timestamp
+
+    summary = records_data.get("summary", {})
+    logger.info(
+        "Kaggle fetch: %d records, %d failed, %.1f min, %.2f rec/s",
+        len(records_data.get("data", [])), summary.get("failed", 0),
+        summary.get("elapsed_s", 0) / 60, summary.get("records_per_second", 0),
+    )
+    
+ 
+    # Save merged records to run folder
+    run_folder_path = Path(run_folder)
+    record_path = run_folder_path / "records.json"
+    record_path.write_text(json.dumps(records_data, indent=2), encoding="utf-8")
+    payload = {
+        "run_folder": run_folder,
+        "data": records_data
+    }
+    return payload
+
+
+@asset(group_name="kaggle_extraction", tags={"pipeline": "Kaggle_etl"}, ins={"raw_data": AssetIn("kaggle_raw_records")})
+def kaggle_models_raw(raw_data: Dict[str, Any]) -> Tuple[str, str]:
+    extractor = KaggleExtractor(records_data=raw_data['data'])
+    models_df = extractor.extract_models()
+    models_df = KaggleHelper.deduplicate_models(models_df)
+
+    models_path = Path(raw_data['run_folder']) / "models.json"
+    models_df.to_json(models_path, orient="records", indent=2)
+    logger.info("Saved %d models to %s", len(models_df), models_path)
+    return (str(models_path), raw_data['run_folder'])
+
+@asset(
+    group_name="kaggle_enrichment",
+    ins={"models_data": AssetIn("kaggle_models_raw")},
+    tags={"pipeline": "Kaggle_etl", "stage": "extract"}
+)
+def kaggle_identified_instances(models_data: Tuple[str, str]) -> Dict[str, List[str]]:
+    """
+    Identify model instance references per model from raw Kaggle models.
+ 
+    A Kaggle model is a container; its downloadable artifacts are instances,
+    one per framework and variation, each with its own license, version, size
+    and URL.
+ 
+    Args:
+        models_data: Tuple of (models_json_path, run_folder)
+ 
+    Returns:
+        Dict of {model_id: [instance_ids]}
+    """
+    models_json_path, _ = models_data
+    enrichment = KaggleEnrichment()
+    models_df = KaggleHelper.load_models_dataframe(models_json_path)
+ 
+    model_instances = enrichment.identifiers["instances"].identify_per_model(models_df)
+    logger.info("Identified instances for %d models", len(model_instances))
+    return model_instances
+
+@asset(
+    group_name="kaggle_enrichment",
+    tags={"pipeline": "Kaggle_etl"},
+    ins={
+        "raw_records": AssetIn("kaggle_raw_records"),
+        "identified_instances": AssetIn("kaggle_identified_instances"),
+    },
+)
+def kaggle_instances_raw(
+    raw_records: Dict[str, Any],
+    identified_instances: Dict[str, List[str]],
+) -> Tuple[str, str]:
+    """
+    Build model instance entity records and save to instances.json.
+    Returns (instances_json_path, run_folder).
+    """
+    records = raw_records["data"]
+    run_folder = raw_records["run_folder"]
+ 
+    instance_ids: Set[str] = set()
+    for _, ids in identified_instances.items():
+        instance_ids.update([x for x in ids if x])
+ 
+    if not instance_ids:
+        logger.info("No instances to extract")
+        return ("", run_folder)
+ 
+    extractor = KaggleExtractor(records_data=records)
+    instances_df = extractor.extract_specific_instances(sorted(instance_ids))
+ 
+    instances_path = Path(run_folder) / "instances.json"
+    instances_df.to_json(str(instances_path), orient="records", indent=2)
+ 
+    logger.info("Saved %d instances to %s", len(instances_df), instances_path)
+    return (str(instances_path), run_folder)
+
+

--- a/etl/assets/kaggle_extraction.py
+++ b/etl/assets/kaggle_extraction.py
@@ -202,3 +202,203 @@ def kaggle_instances_raw(
     return (str(instances_path), run_folder)
 
 
+ 
+@asset(
+    group_name="kaggle_enrichment",
+    ins={"models_data": AssetIn("kaggle_models_raw")},
+    tags={"pipeline": "Kaggle_etl", "stage": "extract"}
+)
+def kaggle_identified_licenses(models_data: Tuple[str, str]) -> Dict[str, List[str]]:
+    """
+    Identify license references per model from raw Kaggle models.
+ 
+    On Kaggle the license belongs to the instance rather than the model, and
+    one model can carry instances under different licenses, so a model may
+    map to several.
+ 
+    Args:
+        models_data: Tuple of (models_json_path, run_folder)
+ 
+    Returns:
+        Dict of {model_id: [license_names]}
+    """
+    models_json_path, _ = models_data
+    enrichment = KaggleEnrichment()
+    models_df = KaggleHelper.load_models_dataframe(models_json_path)
+ 
+    model_licenses = enrichment.identifiers["licenses"].identify_per_model(models_df)
+    logger.info("Identified licenses for %d models", len(model_licenses))
+    return model_licenses
+
+@asset(
+    group_name="kaggle_enrichment",
+    tags={"pipeline": "Kaggle_etl"},
+    ins={
+        "raw_records": AssetIn("kaggle_raw_records"),
+        "identified_licenses": AssetIn("kaggle_identified_licenses"),
+    },
+)
+def kaggle_licenses_raw(
+    raw_records: Dict[str, Any],
+    identified_licenses: Dict[str, List[str]],
+) -> Tuple[str, str]:
+    """
+    Extract license records and save to licenses.json.
+    Returns (licenses_json_path, run_folder).
+    """
+    records = raw_records["data"]
+    run_folder = raw_records["run_folder"]
+ 
+    # Collect unique licenses
+    license_names: Set[str] = set()
+    for _, lic_list in identified_licenses.items():
+        license_names.update([x for x in lic_list if x])
+ 
+    if not license_names:
+        logger.info("No licenses to extract")
+        return ("", run_folder)
+ 
+    extractor = KaggleExtractor(records_data=records)
+    license_df = extractor.extract_specific_licenses(list(license_names))
+ 
+    license_path = Path(run_folder) / "licenses.json"
+    license_df.to_json(str(license_path), orient="records", indent=2)
+ 
+    logger.info("Saved %d licenses to %s", len(license_df), license_path)
+    return (str(license_path), run_folder)
+
+
+@asset(
+    group_name="kaggle_enrichment",
+    ins={"models_data": AssetIn("kaggle_models_raw")},
+    tags={"pipeline": "Kaggle_etl", "stage": "extract"}
+)
+def kaggle_identified_keywords(models_data: Tuple[str, str]) -> Dict[str, List[str]]:
+    """
+    Identify keyword references per model from raw Kaggle models.
+ 
+    Kaggle curates its tags, each carrying a stable ref ("nlp",
+    "classification") and a taxonomy path ("analysis > nlp"). This mapping is
+    what groups models by keyword downstream.
+ 
+    Args:
+        models_data: Tuple of (models_json_path, run_folder)
+ 
+    Returns:
+        Dict of {model_id: [keyword_refs]}
+    """
+    models_json_path, _ = models_data
+    enrichment = KaggleEnrichment()
+    models_df = KaggleHelper.load_models_dataframe(models_json_path)
+ 
+    model_keywords = enrichment.identifiers["keywords"].identify_per_model(models_df)
+    logger.info("Identified keywords for %d models", len(model_keywords))
+    return model_keywords
+ 
+ 
+@asset(
+    group_name="kaggle_enrichment",
+    tags={"pipeline": "Kaggle_etl"},
+    ins={
+        "raw_records": AssetIn("kaggle_raw_records"),
+        "identified_keywords": AssetIn("kaggle_identified_keywords"),
+    },
+)
+def kaggle_keywords_raw(
+    raw_records: Dict[str, Any],
+    identified_keywords: Dict[str, List[str]],
+) -> Tuple[str, str]:
+    """
+    Build keyword entity records and save to keywords.json.
+ 
+    One row per distinct keyword: the same tag repeats identically across
+    every model that carries it, so keywords are de-duplicated by ref - one
+    node, many edges.
+ 
+    Returns (keywords_json_path, run_folder).
+    """
+    records = raw_records["data"]
+    run_folder = raw_records["run_folder"]
+ 
+    keyword_names: Set[str] = set()
+    for _, names in identified_keywords.items():
+        keyword_names.update([x for x in names if x])
+ 
+    if not keyword_names:
+        logger.info("No keywords to extract")
+        return ("", run_folder)
+ 
+    extractor = KaggleExtractor(records_data=records)
+    keywords_df = extractor.extract_specific_keywords(sorted(keyword_names))
+ 
+    keywords_path = Path(run_folder) / "keywords.json"
+    keywords_df.to_json(str(keywords_path), orient="records", indent=2)
+ 
+    logger.info("Saved %d keywords to %s", len(keywords_df), keywords_path)
+    return (str(keywords_path), run_folder)
+
+
+@asset(
+    group_name="kaggle_enrichment",
+    ins={"models_data": AssetIn("kaggle_models_raw")},
+    tags={"pipeline": "Kaggle_etl", "stage": "extract"}
+)
+def kaggle_identified_frameworks(models_data: Tuple[str, str]) -> Dict[str, List[str]]:
+    """
+    Identify framework references per model from raw Kaggle models.
+ 
+    On Kaggle the framework belongs to the instance rather than the model, and
+    one model can carry instances under different frameworks, so a model may
+    map to several.
+ 
+    Args:
+        models_data: Tuple of (models_json_path, run_folder)
+ 
+    Returns:
+        Dict of {model_id: [framework_names]}
+    """
+    models_json_path, _ = models_data
+    enrichment = KaggleEnrichment()
+    models_df = KaggleHelper.load_models_dataframe(models_json_path)
+ 
+    model_frameworks = enrichment.identifiers["frameworks"].identify_per_model(models_df)
+    logger.info("Identified frameworks for %d models", len(model_frameworks))
+    return model_frameworks
+ 
+ 
+@asset(
+    group_name="kaggle_enrichment",
+    tags={"pipeline": "Kaggle_etl"},
+    ins={
+        "raw_records": AssetIn("kaggle_raw_records"),
+        "identified_frameworks": AssetIn("kaggle_identified_frameworks"),
+    },
+)
+def kaggle_frameworks_raw(
+    raw_records: Dict[str, Any],
+    identified_frameworks: Dict[str, List[str]],
+) -> Tuple[str, str]:
+    """
+    Extract framework records and save to frameworks.json.
+    Returns (frameworks_json_path, run_folder).
+    """
+    records = raw_records["data"]
+    run_folder = raw_records["run_folder"]
+ 
+    # Collect unique frameworks
+    framework_names: Set[str] = set()
+    for _, fw_list in identified_frameworks.items():
+        framework_names.update([x for x in fw_list if x])
+ 
+    if not framework_names:
+        logger.info("No frameworks to extract")
+        return ("", run_folder)
+ 
+    extractor = KaggleExtractor(records_data=records)
+    framework_df = extractor.extract_specific_frameworks(list(framework_names))
+ 
+    framework_path = Path(run_folder) / "frameworks.json"
+    framework_df.to_json(str(framework_path), orient="records", indent=2)
+ 
+    logger.info("Saved %d frameworks to %s", len(framework_df), framework_path)
+    return (str(framework_path), run_folder)

--- a/etl/assets/kaggle_extraction.py
+++ b/etl/assets/kaggle_extraction.py
@@ -402,3 +402,59 @@ def kaggle_frameworks_raw(
  
     logger.info("Saved %d frameworks to %s", len(framework_df), framework_path)
     return (str(framework_path), run_folder)
+
+ 
+@asset(
+    group_name="kaggle_enrichment",
+    ins={"models_data": AssetIn("kaggle_models_raw")},
+    tags={"pipeline": "Kaggle_etl", "stage": "extract"}
+)
+def kaggle_identified_sharedby(models_data: Tuple[str, str]) -> Dict[str, List[str]]:
+    """
+    Identify sharedBy entities per model from Kaggle model metadata.
+ 
+    On Kaggle this is the account that uploaded the model, so grouping by it
+    answers "show me everything this person or organization published".
+    """
+    models_json_path, _ = models_data
+    enrichment = KaggleEnrichment()
+    models_df = KaggleHelper.load_models_dataframe(models_json_path)
+ 
+    model_sharedby = enrichment.identifiers["sharedby"].identify_per_model(models_df)
+    logger.info("Identified sharedBy entities for %d models", len(model_sharedby))
+    return model_sharedby
+ 
+ 
+@asset(
+    group_name="kaggle_enrichment",
+    tags={"pipeline": "Kaggle_etl"},
+    ins={
+        "raw_records": AssetIn("kaggle_raw_records"),
+        "identified_sharedby": AssetIn("kaggle_identified_sharedby"),
+    },
+)
+def kaggle_sharedby_raw(
+    raw_records: Dict[str, Any],
+    identified_sharedby: Dict[str, List[str]],
+) -> Tuple[str, str]:
+    """
+    Build sharedBy entity records and save to sharedby.json.
+    Returns (sharedby_json_path, run_folder).
+    """
+    run_folder = raw_records["run_folder"]
+    sharedby_names: Set[str] = set()
+    for _, names in identified_sharedby.items():
+        sharedby_names.update([x for x in names if x])
+ 
+    if not sharedby_names:
+        logger.info("No sharedBy entities to extract")
+        return ("", run_folder)
+ 
+    extractor = KaggleExtractor(records_data=raw_records["data"])
+    sharedby_df = extractor.extract_sharedby(sorted(sharedby_names))
+ 
+    sharedby_path = Path(run_folder) / "sharedby.json"
+    sharedby_df.to_json(str(sharedby_path), orient="records", indent=2)
+ 
+    logger.info("Saved %d sharedBy entities to %s", len(sharedby_df), sharedby_path)
+    return (str(sharedby_path), run_folder)

--- a/etl/assets/kaggle_loading.py
+++ b/etl/assets/kaggle_loading.py
@@ -133,7 +133,13 @@ def kaggle_load_models_to_neo4j(
     normalized_models: str,
     store_ready: Dict[str, Any],
 ) -> Tuple[str, str]:
-    """Load normalized Kaggle models as RDF triples into Neo4j."""
+    """
+    Load normalized Kaggle models as RDF triples into Neo4j.
+
+    ``mlmodels.json`` holds both models and their instances - a Kaggle model
+    is a container and its instances are the downloadable artifacts, each an
+    MLModel in its own right - so one loader covers both.
+    """
     mlmodels_json_path = normalized_models
     normalized_folder = str(Path(mlmodels_json_path).parent)
 
@@ -163,55 +169,6 @@ def kaggle_load_models_to_neo4j(
         **load_stats,
     }
     return (_write_report(rdf_run_folder, "mlmodels", report), normalized_folder)
-
-
-@asset(
-    group_name="kaggle_loading",
-    ins={
-        "instances_normalized": AssetIn("kaggle_instances_normalized"),
-        "store_ready": AssetIn("kaggle_rdf_store_ready"),
-    },
-    tags={"pipeline": "Kaggle_etl", "stage": "load"},
-)
-def kaggle_load_instances_to_neo4j(
-    instances_normalized: str,
-    store_ready: Dict[str, Any],
-) -> Tuple[str, str]:
-    """
-    Load normalized Kaggle model instances as RDF triples into Neo4j.
-
-    Instances are MLModel-shaped - a downloadable artifact of a model, one per
-    framework and variation - so they use the same RDF builder as models but
-    land in their own graph file.
-    """
-    if not instances_normalized or instances_normalized == "":
-        logger.info("No instances to load (empty input)")
-        return ("", "")
-    instances_path = Path(instances_normalized)
-    if not instances_path.exists():
-        logger.warning(f"Instances JSON not found: {instances_normalized}")
-        return ("", "")
-
-    normalized_folder = str(instances_path.parent)
-    config = _store_config(store_ready)
-    rdf_run_folder = _rdf_run_folder(normalized_folder)
-
-    ttl_path = rdf_run_folder / "mlinstances.ttl"
-    load_stats = build_and_persist_models_rdf(
-        json_path=instances_normalized,
-        config=config,
-        output_ttl_path=str(ttl_path),
-        batch_size=50,
-    )
-    report = {
-        "input_file": instances_normalized,
-        "rdf_folder": str(rdf_run_folder),
-        "ttl_file": str(ttl_path),
-        "neo4j_uri": store_ready["uri"],
-        "neo4j_database": store_ready["database"],
-        **load_stats,
-    }
-    return (_write_report(rdf_run_folder, "mlinstances", report), normalized_folder)
 
 
 @asset(
@@ -455,7 +412,6 @@ def kaggle_elasticsearch_ready() -> Dict[str, Any]:
     ins={
         "normalized_models": AssetIn("kaggle_model_normalized"),
         "translation_mapping": AssetIn("kaggle_create_translation_mapping"),
-        "instances_normalized": AssetIn("kaggle_instances_normalized"),
         "frameworks_normalized": AssetIn("kaggle_frameworks_normalized"),
         "es_ready": AssetIn("kaggle_elasticsearch_ready"),
     },
@@ -464,13 +420,10 @@ def kaggle_elasticsearch_ready() -> Dict[str, Any]:
 def kaggle_index_models_elasticsearch(
     normalized_models: str,
     translation_mapping: str,
-    instances_normalized: str,
     frameworks_normalized: str,
     es_ready: Dict[str, Any],
 ) -> str:
     """Index Kaggle models into Elasticsearch (reusing HF document builder)."""
-    if not instances_normalized:
-        logger.info("No Kaggle instances normalized input provided; continuing with model indexing")
     if not frameworks_normalized:
         logger.info("No Kaggle frameworks normalized input provided; continuing with model indexing")
 

--- a/etl/assets/kaggle_loading.py
+++ b/etl/assets/kaggle_loading.py
@@ -1,0 +1,506 @@
+"""
+Dagster assets for Kaggle loading (Neo4j RDF + Elasticsearch).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import logging
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from dagster import AssetIn, asset
+
+from etl.config import get_general_config
+from etl_loaders.elasticsearch_store import ElasticsearchConfig, clean_index
+from etl_loaders.index_loader import check_elasticsearch_connection, index_models
+from etl_loaders.rdf_loader import (
+    build_and_persist_models_rdf,
+    build_and_persist_licenses_rdf,
+    build_and_persist_sources_rdf,
+    build_and_persist_defined_terms_rdf,
+)
+from etl_loaders.metadata_graph import export_metadata_graph_json
+from etl_loaders.rdf_store import (
+    Neo4jConfig,
+    ensure_default_prefixes,
+    get_neo4j_store_config_from_env,
+    get_neosemantics_config,
+    init_neosemantics,
+    reset_database,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _rdf_run_folder(normalized_folder: str) -> Path:
+    """
+    Mirror a normalized run folder under ``3_rdf/kaggle``.
+
+    ``/data/2_normalized/kaggle/<run>`` -> ``/data/3_rdf/kaggle/<run>``
+    """
+    normalized_path = Path(normalized_folder)
+    rdf_run_folder = (
+        normalized_path.parent.parent.parent / "3_rdf" / "kaggle" / normalized_path.name
+    )
+    rdf_run_folder.mkdir(parents=True, exist_ok=True)
+    return rdf_run_folder
+
+
+def _store_config(store_ready: Dict[str, Any]):
+    return get_neo4j_store_config_from_env(
+        batching=store_ready.get("batching", True),
+        batch_size=store_ready.get("batch_size", 5000),
+        multithreading=store_ready.get("multithreading", True),
+        max_workers=store_ready.get("max_workers", 4),
+    )
+
+
+def _write_report(rdf_run_folder: Path, entity_label: str, report: Dict[str, Any]) -> str:
+    report_path = rdf_run_folder / f"{entity_label}_load_report.json"
+    with open(report_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+    return str(report_path)
+
+
+@asset(
+    group_name="kaggle_loading",
+    tags={"pipeline": "Kaggle_etl", "stage": "load"}
+)
+def kaggle_rdf_store_ready() -> Dict[str, Any]:
+    """Verify Neo4j RDF store is configured and ready."""
+    logger.info("Checking Neo4j RDF store readiness...")
+
+    try:
+        env_cfg = Neo4jConfig.from_env()
+        _ = get_neo4j_store_config_from_env(
+            batching=True,
+            batch_size=200,
+            multithreading=True,
+            max_workers=4,
+        )
+        reset_flag = get_general_config().n10s_reset_on_config_change
+        desired_cfg = {"keepCustomDataTypes": True, "handleVocabUris": "SHORTEN"}
+
+        if get_general_config().clean_neo4j_database:
+            logger.warning("Cleaning Neo4j database according to general configuration...")
+            reset_database(drop_config=False)
+        else:
+            logger.info("Keeping Neo4j database according to general configuration...")
+
+        if reset_flag:
+            logger.warning(
+                "N10S_RESET_ON_CONFIG_CHANGE=true -> resetting database and re-initializing n10s"
+            )
+            reset_database(drop_config=True)
+            init_neosemantics(desired_cfg)
+        else:
+            current_cfg = get_neosemantics_config()
+            if not current_cfg:
+                init_neosemantics(desired_cfg)
+            else:
+                logger.info("n10s has existing configuration; skipping re-init on non-empty graph")
+        ensure_default_prefixes()
+
+        logger.info(f"Neo4j RDF store configured: uri={env_cfg.uri}, database={env_cfg.database}")
+        return {
+            "status": "ready",
+            "uri": env_cfg.uri,
+            "database": env_cfg.database,
+            "batching": True,
+            "batch_size": 5000,
+            "multithreading": True,
+            "max_workers": 4,
+        }
+    except ValueError as e:
+        logger.error(f"Neo4j configuration error: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error checking Neo4j store: {e}", exc_info=True)
+        raise
+
+
+@asset(
+    group_name="kaggle_loading",
+    ins={
+        "normalized_models": AssetIn("kaggle_model_normalized"),
+        "store_ready": AssetIn("kaggle_rdf_store_ready"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "load"},
+)
+def kaggle_load_models_to_neo4j(
+    normalized_models: str,
+    store_ready: Dict[str, Any],
+) -> Tuple[str, str]:
+    """Load normalized Kaggle models as RDF triples into Neo4j."""
+    mlmodels_json_path = normalized_models
+    normalized_folder = str(Path(mlmodels_json_path).parent)
+
+    logger.info(f"Loading RDF from normalized models: {mlmodels_json_path}")
+    logger.info(f"Neo4j store status: {store_ready['status']}")
+
+    if not Path(mlmodels_json_path).exists():
+        raise FileNotFoundError(f"mlmodels.json not found: {mlmodels_json_path}")
+
+    config = _store_config(store_ready)
+    rdf_run_folder = _rdf_run_folder(normalized_folder)
+
+    ttl_path = rdf_run_folder / "mlmodels.ttl"
+    load_stats = build_and_persist_models_rdf(
+        json_path=mlmodels_json_path,
+        config=config,
+        output_ttl_path=str(ttl_path),
+        batch_size=50,
+    )
+
+    report = {
+        "input_file": mlmodels_json_path,
+        "rdf_folder": str(rdf_run_folder),
+        "ttl_file": str(ttl_path),
+        "neo4j_uri": store_ready.get("uri"),
+        "neo4j_database": store_ready.get("database"),
+        **load_stats,
+    }
+    return (_write_report(rdf_run_folder, "mlmodels", report), normalized_folder)
+
+
+@asset(
+    group_name="kaggle_loading",
+    ins={
+        "instances_normalized": AssetIn("kaggle_instances_normalized"),
+        "store_ready": AssetIn("kaggle_rdf_store_ready"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "load"},
+)
+def kaggle_load_instances_to_neo4j(
+    instances_normalized: str,
+    store_ready: Dict[str, Any],
+) -> Tuple[str, str]:
+    """
+    Load normalized Kaggle model instances as RDF triples into Neo4j.
+
+    Instances are MLModel-shaped - a downloadable artifact of a model, one per
+    framework and variation - so they use the same RDF builder as models but
+    land in their own graph file.
+    """
+    if not instances_normalized or instances_normalized == "":
+        logger.info("No instances to load (empty input)")
+        return ("", "")
+    instances_path = Path(instances_normalized)
+    if not instances_path.exists():
+        logger.warning(f"Instances JSON not found: {instances_normalized}")
+        return ("", "")
+
+    normalized_folder = str(instances_path.parent)
+    config = _store_config(store_ready)
+    rdf_run_folder = _rdf_run_folder(normalized_folder)
+
+    ttl_path = rdf_run_folder / "mlinstances.ttl"
+    load_stats = build_and_persist_models_rdf(
+        json_path=instances_normalized,
+        config=config,
+        output_ttl_path=str(ttl_path),
+        batch_size=50,
+    )
+    report = {
+        "input_file": instances_normalized,
+        "rdf_folder": str(rdf_run_folder),
+        "ttl_file": str(ttl_path),
+        "neo4j_uri": store_ready["uri"],
+        "neo4j_database": store_ready["database"],
+        **load_stats,
+    }
+    return (_write_report(rdf_run_folder, "mlinstances", report), normalized_folder)
+
+
+@asset(
+    group_name="kaggle_loading",
+    ins={
+        "licenses_normalized": AssetIn("kaggle_licenses_normalized"),
+        "store_ready": AssetIn("kaggle_rdf_store_ready"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "load"}
+)
+def kaggle_load_licenses_to_neo4j(
+    licenses_normalized: str,
+    store_ready: Dict[str, Any],
+) -> Tuple[str, str]:
+    """Load normalized licenses as RDF triples into Neo4j."""
+    if not licenses_normalized or licenses_normalized == "":
+        logger.info("No licenses to load (empty input)")
+        return ("", "")
+    licenses_path = Path(licenses_normalized)
+    if not licenses_path.exists():
+        logger.warning(f"Licenses JSON not found: {licenses_normalized}")
+        return ("", "")
+
+    normalized_folder = str(licenses_path.parent)
+    config = _store_config(store_ready)
+    rdf_run_folder = _rdf_run_folder(normalized_folder)
+
+    ttl_path = rdf_run_folder / "licenses.ttl"
+    load_stats = build_and_persist_licenses_rdf(
+        json_path=licenses_normalized,
+        config=config,
+        output_ttl_path=str(ttl_path),
+    )
+    report = {
+        "input_file": licenses_normalized,
+        "rdf_folder": str(rdf_run_folder),
+        "ttl_file": str(ttl_path),
+        "neo4j_uri": store_ready["uri"],
+        "neo4j_database": store_ready["database"],
+        **load_stats,
+    }
+    return (_write_report(rdf_run_folder, "licenses", report), normalized_folder)
+
+
+@asset(
+    group_name="kaggle_loading",
+    ins={
+        "sources_normalized": AssetIn("kaggle_sources_normalized"),
+        "store_ready": AssetIn("kaggle_rdf_store_ready"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "load"},
+)
+def kaggle_load_sources_to_neo4j(
+    sources_normalized: str,
+    store_ready: Dict[str, Any],
+) -> Tuple[str, str]:
+    """Load normalized source websites as RDF triples into Neo4j."""
+    if not sources_normalized or sources_normalized == "":
+        logger.info("No sources to load (empty input)")
+        return ("", "")
+
+    sources_path = Path(sources_normalized)
+    if not sources_path.exists():
+        logger.warning(f"Sources JSON not found: {sources_normalized}")
+        return ("", "")
+
+    normalized_folder = str(sources_path.parent)
+    config = _store_config(store_ready)
+    rdf_run_folder = _rdf_run_folder(normalized_folder)
+
+    ttl_path = rdf_run_folder / "sources.ttl"
+    load_stats = build_and_persist_sources_rdf(
+        json_path=sources_normalized,
+        config=config,
+        output_ttl_path=str(ttl_path),
+    )
+    report = {
+        "input_file": sources_normalized,
+        "rdf_folder": str(rdf_run_folder),
+        "ttl_file": str(ttl_path),
+        "neo4j_uri": store_ready["uri"],
+        "neo4j_database": store_ready["database"],
+        **load_stats,
+    }
+    return (_write_report(rdf_run_folder, "sources", report), normalized_folder)
+
+
+@asset(
+    group_name="kaggle_loading",
+    ins={
+        "keywords_normalized": AssetIn("kaggle_keywords_normalized"),
+        "store_ready": AssetIn("kaggle_rdf_store_ready"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "load"}
+)
+def kaggle_load_keywords_to_neo4j(
+    keywords_normalized: str,
+    store_ready: Dict[str, Any],
+) -> Tuple[str, str]:
+    """Load normalized keywords as RDF triples into Neo4j."""
+    if not keywords_normalized or keywords_normalized == "":
+        logger.info("No keywords to load (empty input)")
+        return ("", "")
+    keywords_path = Path(keywords_normalized)
+    if not keywords_path.exists():
+        logger.warning(f"Keywords JSON not found: {keywords_normalized}")
+        return ("", "")
+
+    normalized_folder = str(keywords_path.parent)
+    config = _store_config(store_ready)
+    rdf_run_folder = _rdf_run_folder(normalized_folder)
+
+    ttl_path = rdf_run_folder / "keywords.ttl"
+    load_stats = build_and_persist_defined_terms_rdf(
+        json_path=keywords_normalized,
+        config=config,
+        output_ttl_path=str(ttl_path),
+        entity_label="keywords",
+    )
+    report = {
+        "input_file": keywords_normalized,
+        "rdf_folder": str(rdf_run_folder),
+        "ttl_file": str(ttl_path),
+        "neo4j_uri": store_ready["uri"],
+        "neo4j_database": store_ready["database"],
+        **load_stats,
+    }
+    return (_write_report(rdf_run_folder, "keywords", report), normalized_folder)
+
+
+@asset(
+    group_name="kaggle_loading",
+    ins={
+        "frameworks_normalized": AssetIn("kaggle_frameworks_normalized"),
+        "store_ready": AssetIn("kaggle_rdf_store_ready"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "load"}
+)
+def kaggle_load_frameworks_to_neo4j(
+    frameworks_normalized: str,
+    store_ready: Dict[str, Any],
+) -> Tuple[str, str]:
+    """Load normalized frameworks as RDF triples into Neo4j."""
+    if not frameworks_normalized or frameworks_normalized == "":
+        logger.info("No frameworks to load (empty input)")
+        return ("", "")
+    frameworks_path = Path(frameworks_normalized)
+    if not frameworks_path.exists():
+        logger.warning(f"Frameworks JSON not found: {frameworks_normalized}")
+        return ("", "")
+
+    normalized_folder = str(frameworks_path.parent)
+    config = _store_config(store_ready)
+    rdf_run_folder = _rdf_run_folder(normalized_folder)
+
+    ttl_path = rdf_run_folder / "frameworks.ttl"
+    load_stats = build_and_persist_defined_terms_rdf(
+        json_path=frameworks_normalized,
+        config=config,
+        output_ttl_path=str(ttl_path),
+        entity_label="frameworks",
+    )
+    report = {
+        "input_file": frameworks_normalized,
+        "rdf_folder": str(rdf_run_folder),
+        "ttl_file": str(ttl_path),
+        "neo4j_uri": store_ready["uri"],
+        "neo4j_database": store_ready["database"],
+        **load_stats,
+    }
+    return (_write_report(rdf_run_folder, "frameworks", report), normalized_folder)
+
+
+@asset(
+    group_name="kaggle_loading",
+    ins={
+        "models_loaded": AssetIn("kaggle_load_models_to_neo4j"),
+        "store_ready": AssetIn("kaggle_rdf_store_ready"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "load"},
+)
+def kaggle_export_metadata_json(
+    models_loaded: Tuple[str, str],
+    store_ready: Dict[str, Any],
+) -> str:
+    """Export metadata graph JSON for Kaggle run."""
+    models_report_path, normalized_folder = models_loaded
+    rdf_run_folder = _rdf_run_folder(normalized_folder)
+
+    json_path = rdf_run_folder / "metadata.json"
+    rdf_report_path = rdf_run_folder / "metadata_export_report.json"
+
+    enabled = bool(get_general_config().save_loaded_extraction_metadata_file)
+    if not enabled:
+        report = {
+            "status": "skipped",
+            "reason": "save_loaded_extraction_metadata_file is disabled in general config",
+            "models_report_input": models_report_path,
+            "rdf_folder": str(rdf_run_folder),
+            "json_file": str(json_path),
+            "neo4j_uri": store_ready.get("uri"),
+            "neo4j_database": store_ready.get("database"),
+        }
+        with open(rdf_report_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False)
+        return str(rdf_report_path)
+
+    export_stats = export_metadata_graph_json(output_json_path=str(json_path))
+    report = {
+        "status": "ok",
+        "models_report_input": models_report_path,
+        "rdf_folder": str(rdf_run_folder),
+        "json_file": str(json_path),
+        "neo4j_uri": store_ready.get("uri"),
+        "neo4j_database": store_ready.get("database"),
+        **export_stats,
+    }
+    with open(rdf_report_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+    return str(rdf_report_path)
+
+
+@asset(
+    group_name="kaggle_loading",
+    tags={"pipeline": "Kaggle_etl", "stage": "index"},
+)
+def kaggle_elasticsearch_ready() -> Dict[str, Any]:
+    """Verify Elasticsearch is configured and ready for Kaggle indexing."""
+    status = check_elasticsearch_connection()
+    kaggle_index = os.getenv("ELASTIC_KAGGLE_MODELS_INDEX", "kaggle_models")
+    status["kaggle_models_index"] = kaggle_index
+
+    if get_general_config().clean_elasticsearch_index:
+        cfg = ElasticsearchConfig.from_env()
+        clean_index(kaggle_index, cfg=cfg)
+    return status
+
+
+@asset(
+    group_name="kaggle_loading",
+    ins={
+        "normalized_models": AssetIn("kaggle_model_normalized"),
+        "translation_mapping": AssetIn("kaggle_create_translation_mapping"),
+        "instances_normalized": AssetIn("kaggle_instances_normalized"),
+        "frameworks_normalized": AssetIn("kaggle_frameworks_normalized"),
+        "es_ready": AssetIn("kaggle_elasticsearch_ready"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "index"},
+)
+def kaggle_index_models_elasticsearch(
+    normalized_models: str,
+    translation_mapping: str,
+    instances_normalized: str,
+    frameworks_normalized: str,
+    es_ready: Dict[str, Any],
+) -> str:
+    """Index Kaggle models into Elasticsearch (reusing HF document builder)."""
+    if not instances_normalized:
+        logger.info("No Kaggle instances normalized input provided; continuing with model indexing")
+    if not frameworks_normalized:
+        logger.info("No Kaggle frameworks normalized input provided; continuing with model indexing")
+
+    mlmodels_json_path = normalized_models
+    normalized_folder = str(Path(mlmodels_json_path).parent)
+    rdf_run_folder = _rdf_run_folder(normalized_folder)
+
+    json_file = Path(mlmodels_json_path)
+    if not json_file.exists():
+        raise FileNotFoundError(f"Normalized models file not found: {mlmodels_json_path}")
+
+    cfg = ElasticsearchConfig.from_env()
+    index_name = es_ready.get("kaggle_models_index") or os.getenv(
+        "ELASTIC_KAGGLE_MODELS_INDEX", "kaggle_models"
+    )
+
+    stats = index_models(
+        json_path=mlmodels_json_path,
+        translation_mapping_path=translation_mapping,
+        index_name=index_name,
+        es_config=cfg,
+    )
+    stats.update(
+        {
+            "normalized_folder": normalized_folder,
+            "cluster_name": es_ready.get("cluster_name"),
+            "rdf_run_folder": str(rdf_run_folder),
+        }
+    )
+    elasticsearch_report_path = rdf_run_folder / "elasticsearch_report.json"
+    with open(elasticsearch_report_path, "w", encoding="utf-8") as f:
+        json.dump(stats, f, indent=2, ensure_ascii=False)
+    return str(elasticsearch_report_path)

--- a/etl/assets/kaggle_transformation.py
+++ b/etl/assets/kaggle_transformation.py
@@ -1,0 +1,1216 @@
+"""
+Dagster assets for Kaggle -> FAIR4ML transformation.
+
+Pipeline:
+1) Read raw Kaggle models from extraction (models.json)
+2) Create separate assets for each property group:
+    - mlmodels.json       (FAIR4ML MLModel)
+    - mlinstances.json    (FAIR4ML MLModel, one per downloadable instance)
+    - entity_linking.json (linkage of model -> keywords/licenses/frameworks)
+
+Instances are written to their own file rather than mlmodels.json. A Kaggle
+model is a container and its instances are the downloadable artifacts, so
+folding them in would turn ~43k models into ~60k+ search results that are
+mostly the same model repackaged. The relationships survive either way -
+``parent_mlentory_id`` links an instance to its model and ``baseModel`` links
+a fine-tune to what it was derived from - so the graph can still answer
+"show me every variation of Gemma" and "show me models built on Gemma".
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple, List, Dict, Any, Optional
+import logging
+
+from pydantic import BaseModel, ValidationError
+from dagster import asset, AssetIn
+
+from etl_extractors.kaggle.kaggle_helper import KaggleHelper
+from etl_transformers.kaggle.transform_mlmodel import map_kaggle_basic_properties
+from etl_transformers.common.entity_link_metadata import (
+    apply_entity_link_extraction_metadata,
+)
+from schemas.fair4ml import MLModel
+from schemas.schemaorg import DefinedTerm
+
+
+logger = logging.getLogger(__name__)
+
+
+def _json_default(o):
+    """Non-recursive JSON serializer for known non-serializable types."""
+    if isinstance(o, BaseModel):
+        return o.model_dump(mode='json', by_alias=True)
+    if isinstance(o, datetime):
+        return o.isoformat()
+    if isinstance(o, Path):
+        return str(o)
+    if isinstance(o, set):
+        return list(o)
+    if isinstance(o, tuple):
+        return list(o)
+    return str(o)
+
+
+def _load_json_records(path: str) -> List[Dict[str, Any]]:
+    """Load a JSON file that should hold a list of records."""
+    if not path:
+        return []
+    file_path = Path(path)
+    if not file_path.exists():
+        logger.warning("Expected JSON file not found: %s", path)
+        return []
+    with open(file_path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if isinstance(data, dict):
+        return [v for v in data.values() if isinstance(v, dict)]
+    if isinstance(data, list):
+        return [x for x in data if isinstance(x, dict)]
+    return []
+
+
+def _clean_framework(framework: str) -> str:
+    """
+    Turn Kaggle's framework field into the display form used in instance URLs.
+
+    ``MODEL_FRAMEWORK_TENSOR_FLOW_2`` and ``pyTorch`` both become the form the
+    instance ids are built from, so base-model references resolve to the same
+    hash as the instance they point at.
+    """
+    if not framework:
+        return ""
+    name = framework
+    if name.startswith("MODEL_FRAMEWORK_"):
+        name = name[len("MODEL_FRAMEWORK_"):]
+    if name and name[0].islower() and "_" not in name:
+        # pyTorch -> PyTorch, keras -> Keras, scikitLearn -> ScikitLearn
+        return name[0].upper() + name[1:]
+    parts = [p for p in name.split("_") if p]
+    return "".join(p.capitalize() for p in parts)
+
+
+# ---------- normalized folder ----------
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={"models_data": AssetIn("kaggle_models_raw")},
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_normalized_model_folder(models_data: Tuple[str, str]) -> Tuple[str, str]:
+    """
+    Create normalized run folder mirroring raw run folder name.
+    """
+    raw_data_json_path, raw_run_folder = models_data
+
+    # unique per run
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    run_id = str(uuid.uuid4())[:8]
+
+    normalized_base = Path("/data/2_normalized/kaggle")
+    normalized_run_folder = normalized_base / f"{timestamp}_{run_id}"
+    normalized_run_folder.mkdir(parents=True, exist_ok=True)
+
+    logger.info(f"Created normalized run folder: {normalized_run_folder}")
+    return (str(raw_data_json_path), str(normalized_run_folder))
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={"models_data": AssetIn("kaggle_normalized_model_folder")},
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_extract_basic_properties(models_data: Tuple[str, str]) -> str:
+    """
+    Produces FAIR4ML-style partial_basic_properties.json for Kaggle models.
+
+    Input:  (raw_models_json_path, normalized_folder)
+    Output: <normalized_folder>/partial_basic_properties.json
+    """
+    raw_models_json_path, normalized_folder = models_data
+
+    logger.info("Loading raw models from %s", raw_models_json_path)
+    with open(raw_models_json_path, "r", encoding="utf-8") as f:
+        raw_payload = json.load(f)
+
+    if isinstance(raw_payload, list):
+        raw_models = raw_payload
+    elif isinstance(raw_payload, dict):
+        raw_models = (
+            raw_payload.get("models")
+            or raw_payload.get("data")
+            or raw_payload.get("items")
+            or []
+        )
+    else:
+        raw_models = []
+
+    if not isinstance(raw_models, list):
+        raise ValueError(f"Expected list of models, got: {type(raw_models).__name__}")
+
+    logger.info("Loaded %d raw models", len(raw_models))
+
+    out: List[Dict[str, Any]] = []
+
+    for idx, raw_model in enumerate(raw_models):
+        model_id = ""
+        if isinstance(raw_model, dict):
+            model_id = str(raw_model.get("modelId", "")).strip()
+        if not model_id:
+            model_id = f"unknown_{idx}"
+
+        if not isinstance(raw_model, dict):
+            out.append(
+                {
+                    "identifier": [],
+                    "name": model_id,
+                    "url": [],
+                    "author": "",
+                    "sharedBy": "",
+                    "modelCategory": [],
+                    "citation": [],
+                    "intendedUse": "",
+                    "dateCreated": "",
+                    "dateModified": "",
+                    "datePublished": "",
+                    "description": "",
+                    "abstract": "",
+                    "discussionUrl": "",
+                    "archivedAt": "",
+                    "readme": "",
+                    "issueTracker": "",
+                    "extraction_metadata": {},
+                    "_model_id": model_id,
+                    "_index": idx,
+                    "_error": f"Model is not a dict: {type(raw_model).__name__}",
+                }
+            )
+            continue
+
+        try:
+            mapped = map_kaggle_basic_properties(raw_model)
+
+            mapped["_index"] = idx
+            mapped["_model_id"] = mapped.get("_model_id") or model_id
+
+            if "extraction_metadata" not in mapped or mapped["extraction_metadata"] is None:
+                mapped["extraction_metadata"] = {}
+
+            out.append(mapped)
+
+            if (idx + 1) % 200 == 0:
+                logger.info("Extracted basic properties for %d/%d models", idx + 1, len(raw_models))
+
+        except Exception as e:
+            logger.error("Error extracting basic properties for %s: %s", model_id, e, exc_info=True)
+
+            out.append(
+                {
+                    "identifier": [str(raw_model.get("mlentory_id", "")).strip()],
+                    "name": str(raw_model.get("name", "")).strip() or model_id,
+                    "url": [str(raw_model.get("url", "")).strip()],
+                    "author": "",
+                    "sharedBy": str(raw_model.get("sharedBy", "")).strip(),
+                    "modelCategory": [],
+                    "citation": [],
+                    "intendedUse": str(raw_model.get("intendedUse", "")).strip(),
+                    "dateCreated": str(raw_model.get("dateCreated", "")).strip(),
+                    "dateModified": str(raw_model.get("dateModified", "")).strip(),
+                    "datePublished": str(raw_model.get("datePublished", "")).strip()
+                                   or str(raw_model.get("dateModified", "")).strip(),
+                    "description": str(raw_model.get("intendedUse", "")).strip(),
+                    "abstract": str(raw_model.get("intendedUse", "")).strip(),
+                    "discussionUrl": "",
+                    "archivedAt": str(raw_model.get("url", "")).strip(),
+                    "readme": "",
+                    "issueTracker": "",
+                    "extraction_metadata": {},
+                    "_model_id": model_id,
+                    "_index": idx,
+                    "_error": str(e),
+                }
+            )
+
+    output_path = Path(normalized_folder) / "partial_basic_properties.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=2, ensure_ascii=False, default=_json_default)
+
+    logger.info("Saved basic properties to %s", output_path)
+    return str(output_path)
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={"run_folder_data": AssetIn("kaggle_normalized_model_folder")},
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_sources_normalized(run_folder_data: Tuple[str, str]) -> str:
+    """
+    Bring the Kaggle catalog ``WebSite`` from raw extract into this run's
+    normalized folder as ``sources.json``.
+    """
+    raw_models_path, normalized_folder = run_folder_data
+    raw_run = Path(raw_models_path).parent
+    raw_sources = raw_run / "sources.json"
+    out_path = Path(normalized_folder) / "sources.json"
+
+    if raw_sources.exists():
+        with open(raw_sources, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        logger.info("Loaded Kaggle catalog sources from raw run: %s", raw_sources)
+    else:
+        logger.warning(
+            "Raw sources.json missing at %s; using KaggleHelper catalog payload",
+            raw_sources,
+        )
+        payload = KaggleHelper.raw_kaggle_catalog_website_records()
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False, default=_json_default)
+
+    logger.info("Wrote normalized Kaggle sources to %s", out_path)
+    return str(out_path)
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={
+        "keywords_mapping": AssetIn("kaggle_identified_keywords"),
+        "licenses_mapping": AssetIn("kaggle_identified_licenses"),
+        "frameworks_mapping": AssetIn("kaggle_identified_frameworks"),
+        "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_entity_linking(
+    keywords_mapping: Dict[str, List[str]],
+    licenses_mapping: Dict[str, List[str]],
+    frameworks_mapping: Dict[str, List[str]],
+    run_folder_data: Tuple[str, str],
+) -> str:
+    """
+    Create entity linking mapping: model_id -> {keywords, licenses, frameworks, sources}
+    Links identified entities with their enriched metadata.
+
+    Args:
+        keywords_mapping: {model_id: [keyword_refs]}
+        licenses_mapping: {model_id: [license_names]}
+        frameworks_mapping: {model_id: [framework_names]}
+        run_folder_data: Tuple of (raw_models_json_path, normalized_folder)
+
+    Returns:
+        Path to saved entity linking JSON file
+    """
+    _, normalized_folder = run_folder_data
+
+    kaggle_catalog_source_iris: List[str] = []
+    for row in KaggleHelper.raw_kaggle_catalog_website_records():
+        ids = row.get("https://schema.org/identifier") or []
+        if not isinstance(ids, list):
+            continue
+        kaggle_catalog_source_iris = [
+            u
+            for u in ids
+            if isinstance(u, str)
+            and u.startswith("https://w3id.org/mlentory/mlentory_graph/")
+        ]
+        if kaggle_catalog_source_iris:
+            break
+
+    # union of ids so you don't KeyError if a model appears in only one mapping
+    all_model_ids = (
+        set(keywords_mapping.keys())
+        | set(licenses_mapping.keys())
+        | set(frameworks_mapping.keys())
+    )
+
+    entity_linking: Dict[str, Dict[str, List[str]]] = {}
+
+    for model_id in all_model_ids:
+        keywords = keywords_mapping.get(model_id, []) or []
+        licenses = licenses_mapping.get(model_id, []) or []
+        frameworks = frameworks_mapping.get(model_id, []) or []
+
+        entity_linking[model_id] = {
+            "keywords": [
+                KaggleHelper.generate_mlentory_entity_hash_id("Keyword", x, platform="Kaggle")
+                for x in keywords
+            ],
+            "licenses": [
+                KaggleHelper.generate_mlentory_entity_hash_id("License", x, platform="Kaggle")
+                for x in licenses
+            ],
+            "frameworks": [
+                KaggleHelper.generate_mlentory_entity_hash_id("Framework", x, platform="Kaggle")
+                for x in frameworks
+            ],
+            "sources": list(kaggle_catalog_source_iris),
+        }
+
+    output_path = Path(normalized_folder) / "entity_linking.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(entity_linking, f, indent=2, ensure_ascii=False)
+
+    logger.info("Saved entity linking data for %d models to %s", len(entity_linking), output_path)
+    return str(output_path)
+
+
+def merge_kaggle_partial_schemas(
+    basic_by_id: Dict[str, Dict[str, Any]],
+    entity_linking_data: Dict[str, Dict[str, Any]],
+    all_model_ids: List[str],
+) -> List[Tuple[str, Dict[str, Any]]]:
+    """
+    Merge basic properties + entity linking into a dict compatible with MLModel(**data).
+
+    Returns:
+        List of (model_id, merged_dict)
+    """
+    merged_items: List[Tuple[str, Dict[str, Any]]] = []
+
+    for model_id in all_model_ids:
+        bp = basic_by_id.get(model_id) or {}
+        links = entity_linking_data.get(model_id) or {}
+
+        merged_data: Dict[str, Any] = dict(bp)
+        merged_data.pop("_model_id", None)
+        merged_data.pop("_index", None)
+        merged_data.pop("_error", None)
+
+        keywords = links.get("keywords") or []
+        licenses = links.get("licenses") or []
+        frameworks = links.get("frameworks") or []
+        sources = links.get("sources") or []
+        linked_fields: List[str] = []
+
+        if keywords:
+            existing = merged_data.get("keywords") or []
+            if not isinstance(existing, list):
+                existing = []
+            merged_data["keywords"] = list(dict.fromkeys(existing + list(keywords)))
+            linked_fields.append("keywords")
+
+        if licenses:
+            merged_data["license"] = str(licenses[0])  # MLModel.license is a single string
+            linked_fields.append("license")
+
+        if frameworks:
+            # Frameworks replace the raw modelCategory strings with their IRIs
+            merged_data["modelCategory"] = list(frameworks)
+            linked_fields.append("modelCategory")
+
+        if sources:
+            merged_data["source"] = str(sources[0])  # MLModel.source is a single string
+            linked_fields.append("source")
+
+        apply_entity_link_extraction_metadata(merged_data, "kaggle", linked_fields)
+
+        # Minimal required fields
+        if not merged_data.get("name"):
+            merged_data["name"] = model_id
+
+        if not isinstance(merged_data.get("identifier"), list):
+            merged_data["identifier"] = []
+
+        # --- Coerce fields to match MLModel schema ---
+
+        # modelCategory must be List[str] in schema
+        mc = merged_data.get("modelCategory")
+        if isinstance(mc, str):
+            merged_data["modelCategory"] = [mc] if mc.strip() else []
+        elif isinstance(mc, list):
+            merged_data["modelCategory"] = [str(x) for x in mc if str(x).strip()]
+
+        cit = merged_data.get("citation")
+        if cit is None or not isinstance(cit, list):
+            merged_data["citation"] = []
+
+        iu = merged_data.get("intendedUse")
+        if iu is not None and not isinstance(iu, str):
+            merged_data["intendedUse"] = str(iu)
+
+        merged_items.append((model_id, merged_data))
+
+    return merged_items
+
+
+def validate_kaggle_mlmodels(
+    merged_items: List[Tuple[str, Dict[str, Any]]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """
+    Validate merged dicts against MLModel and return:
+      - normalized models (as dicts)
+      - validation errors (as dicts)
+    """
+    normalized: List[Dict[str, Any]] = []
+    errors: List[Dict[str, Any]] = []
+
+    for idx, (model_id, data) in enumerate(merged_items):
+        try:
+            obj = MLModel(**data)
+            normalized.append(obj.model_dump(mode="json", by_alias=True))
+
+        except ValidationError as ve:
+            errors.append(
+                {
+                    "_model_id": model_id,
+                    "_index": idx,
+                    "_error": "MLModel validation failed",
+                    "details": ve.errors(),
+                    "merged_data": data,
+                }
+            )
+        except Exception as e:
+            errors.append(
+                {
+                    "_model_id": model_id,
+                    "_index": idx,
+                    "_error": str(e),
+                    "error_type": type(e).__name__,
+                    "merged_data": data,
+                }
+            )
+
+    return normalized, errors
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={
+        "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
+        "basic_properties_path": AssetIn("kaggle_extract_basic_properties"),
+        "entity_linking_path": AssetIn("kaggle_entity_linking"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_model_normalized(
+    run_folder_data: Tuple[str, str],
+    basic_properties_path: str,
+    entity_linking_path: str,
+) -> str:
+    """
+    Builds FAIR4ML-validated MLModel objects for Kaggle.
+
+    Inputs:
+      - run_folder_data: (raw_models_json_path, normalized_run_folder)
+      - basic_properties_path: .../partial_basic_properties.json
+      - entity_linking_path: .../entity_linking.json
+
+    Output:
+      - .../mlmodels.json in the normalized_run_folder
+    """
+    raw_models_json_path, normalized_folder = run_folder_data
+    normalized_folder_path = Path(normalized_folder)
+    normalized_folder_path.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Loading raw models from %s", raw_models_json_path)
+    with open(raw_models_json_path, "r", encoding="utf-8") as f:
+        raw_payload = json.load(f)
+
+    if isinstance(raw_payload, list):
+        raw_models = raw_payload
+    elif isinstance(raw_payload, dict):
+        raw_models = (
+            raw_payload.get("models")
+            or raw_payload.get("data")
+            or raw_payload.get("items")
+            or []
+        )
+    else:
+        raw_models = []
+
+    if not isinstance(raw_models, list):
+        raise ValueError(f"Expected list of raw models, got: {type(raw_models).__name__}")
+
+    raw_ids: List[str] = []
+    for i, rm in enumerate(raw_models):
+        if isinstance(rm, dict):
+            mid = str(rm.get("modelId", "")).strip() or f"unknown_{i}"
+        else:
+            mid = f"unknown_{i}"
+        raw_ids.append(mid)
+
+    logger.info("Loading partial basic properties from %s", basic_properties_path)
+    with open(basic_properties_path, "r", encoding="utf-8") as f:
+        basic_list = json.load(f)
+
+    if not isinstance(basic_list, list):
+        raise ValueError(
+            f"Expected list in partial_basic_properties.json, got: {type(basic_list).__name__}"
+        )
+
+    basic_by_id: Dict[str, Dict[str, Any]] = {}
+    for i, bp in enumerate(basic_list):
+        if not isinstance(bp, dict):
+            continue
+        mid = str(bp.get("_model_id", "")).strip() or f"unknown_{i}"
+        basic_by_id[mid] = bp
+
+    logger.info("Loading entity linking from %s", entity_linking_path)
+    with open(entity_linking_path, "r", encoding="utf-8") as f:
+        entity_linking = json.load(f)
+
+    if not isinstance(entity_linking, dict):
+        raise ValueError(
+            f"Expected dict in entity_linking.json, got: {type(entity_linking).__name__}"
+        )
+
+    all_ids = list(
+        dict.fromkeys(raw_ids + list(basic_by_id.keys()) + list(entity_linking.keys()))
+    )
+
+    merged_items = merge_kaggle_partial_schemas(
+        basic_by_id=basic_by_id,
+        entity_linking_data=entity_linking,
+        all_model_ids=all_ids,
+    )
+
+    normalized_models, validation_errors = validate_kaggle_mlmodels(merged_items)
+
+    if not normalized_models:
+        raise RuntimeError("kaggle_model_normalized produced zero valid MLModels. Aborting run.")
+
+    output_path = normalized_folder_path / "mlmodels.json"
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(normalized_models, f, indent=2, ensure_ascii=False, default=str)
+
+    if validation_errors:
+        errors_path = normalized_folder_path / "transformation_errors.json"
+        with open(errors_path, "w", encoding="utf-8") as f:
+            json.dump(validation_errors, f, indent=2, ensure_ascii=False, default=str)
+        logger.warning(
+            "Wrote %d valid models; %d failed validation. Errors saved to %s",
+            len(normalized_models),
+            len(validation_errors),
+            errors_path,
+        )
+
+    logger.info("Saved mlmodels.json to %s", output_path)
+    return str(output_path)
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={
+        "instances_data": AssetIn("kaggle_instances_raw"),
+        "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_instances_normalized(
+    instances_data: Tuple[str, str],
+    run_folder_data: Tuple[str, str],
+) -> str:
+    """
+    Normalize Kaggle model instances into FAIR4ML MLModel objects and write
+    <normalized_folder>/mlinstances.json.
+
+    An instance is a downloadable artifact of a model - one per framework and
+    variation - so only the fields it genuinely owns are mapped: its own name,
+    overview, usage snippet, license, size and URL.
+
+    ``baseModel`` carries two kinds of link, real lineage first: the model an
+    instance was derived from (from ``baseModelInstanceInformation``), then
+    the parent model it belongs to. Both land as ``fair4ml:baseModel`` edges,
+    which gives the graph a parent node with its variations as children -
+    "show me every variation of Gemma" - at the cost of not separating
+    "packaged from" from "derived from" in the predicate itself.
+    """
+    instances_json_path, _raw_run_folder = instances_data
+    _raw_models_json_path, normalized_folder = run_folder_data
+
+    out_path = Path(normalized_folder) / "mlinstances.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not instances_json_path:
+        logger.info("No instances_json_path. Writing empty mlinstances.json")
+        out_path.write_text("[]", encoding="utf-8")
+        return str(out_path)
+
+    raw_instances = _load_json_records(instances_json_path)
+    logger.info("Loading Kaggle instances from %s (%d records)", instances_json_path, len(raw_instances))
+
+    normalized: List[Dict[str, Any]] = []
+    errors: List[Dict[str, Any]] = []
+
+    for idx, rec in enumerate(raw_instances):
+        instance_id = str(rec.get("instanceId", "")).strip() or f"instance_{idx}"
+
+        try:
+            mlentory_id = str(rec.get("mlentory_id", "")).strip()
+            parent_id = str(rec.get("parent_mlentory_id", "")).strip()
+            url = str(rec.get("url", "")).strip()
+
+            identifiers = [x for x in (mlentory_id,) if x]
+            urls = [x for x in (url,) if x]
+            if mlentory_id.startswith("https://w3id.org/mlentory/"):
+                urls.append(
+                    mlentory_id.replace(
+                        "https://w3id.org/mlentory/", "https://mlentory.zbmed.de/", 1
+                    )
+                )
+
+            # Real lineage only: base model reconstructed from the nested
+            # baseModelInstanceInformation object. The framework there uses the
+            # field spelling ("pyTorch"), so it is normalized to the URL form
+            # the instance ids are built from, or the hash would not match.
+            base_models: List[str] = []
+            base_info = rec.get("baseModelInstanceInformation")
+            if isinstance(base_info, str) and base_info.strip():
+                try:
+                    base_info = json.loads(base_info)
+                except (ValueError, TypeError):
+                    base_info = None
+            if isinstance(base_info, dict):
+                owner = base_info.get("owner")
+                owner_slug = ""
+                if isinstance(owner, dict):
+                    owner_slug = str(owner.get("slug", "")).strip()
+                model_slug = str(base_info.get("modelSlug", "")).strip()
+                instance_slug = str(base_info.get("instanceSlug", "")).strip()
+                framework = _clean_framework(str(base_info.get("framework", "")).strip())
+                parts = [p for p in (owner_slug, model_slug, framework, instance_slug) if p]
+                if len(parts) == 4:
+                    base_ref = "/".join(parts)
+                    base_models.append(
+                        KaggleHelper.generate_mlentory_entity_hash_id(
+                            "ModelInstance", base_ref, platform="Kaggle"
+                        )
+                    )
+
+            external_base = str(rec.get("externalBaseModelUrl", "")).strip()
+            if external_base and external_base not in base_models:
+                base_models.append(external_base)
+
+            # The parent model this instance belongs to. Added last so real
+            # lineage stays at index 0 for anything that needs to tell the two
+            # apart. Without it 57 of 58 instances have no edges at all and sit
+            # orphaned in the graph, so an imprecise edge beats none: this is
+            # what makes "show every variation of Gemma" answerable.
+            #
+            # The precise fix is schema:isPartOf added to the mapped property
+            # list in rdf_loader.build_model_triples - one IRI in a shared
+            # file - which would separate "packaged from" from "derived from".
+            if parent_id and parent_id not in base_models:
+                base_models.append(parent_id)
+
+            # The instance's own documentation. `overview` is the short
+            # summary Kaggle shows on the variation page; `usage` is the long
+            # form - intended uses, sample code, limitations, training notes -
+            # and is often richer than the parent model card. abstract holds
+            # both, matching what it means at model level: the complete
+            # original text for this record.
+            overview = str(rec.get("description", "")).strip()
+            usage = str(rec.get("usage", "")).strip()
+            full_card = "\n\n".join(part for part in (overview, usage) if part)
+
+            payload: Dict[str, Any] = {
+                "identifier": identifiers,
+                "name": str(rec.get("name", "")).strip() or instance_id,
+                "url": list(dict.fromkeys(urls)),
+                "author": str(rec.get("parent_name", "")).strip() or None,
+                "description": overview or None,
+                "abstract": full_card or None,
+                "license": str(rec.get("license", "")).strip() or None,
+                "modelCategory": [
+                    x for x in (str(rec.get("frameworkName", "")).strip(),) if x
+                ],
+                "baseModel": base_models,
+                "usageInstructions": usage or None,
+                "memoryRequirements": str(rec.get("contentSize", "")).strip() or None,
+                "archivedAt": url or None,
+                "metrics": {
+                    "version": rec.get("version"),
+                    "fineTunable": rec.get("fineTunable"),
+                    "parentModel": parent_id,
+                },
+                "extraction_metadata": {
+                    "identifier": {
+                        "extraction_method": "Parsed_from_Kaggle_instances_json",
+                        "confidence": 1.0,
+                        "source_field": "mlentory_id",
+                    },
+                    "name": {
+                        "extraction_method": "Parsed_from_Kaggle_instances_json",
+                        "confidence": 1.0,
+                        "source_field": "slug",
+                    },
+                    "description": {
+                        "extraction_method": "Parsed_from_Kaggle_instances_json",
+                        "confidence": 1.0,
+                        "source_field": "overview",
+                    },
+                    "abstract": {
+                        "extraction_method": "Parsed_from_Kaggle_instances_json",
+                        "confidence": 1.0,
+                        "source_field": "overview, usage",
+                        "notes": "Full instance documentation before summarization",
+                    },
+                    "license": {
+                        "extraction_method": "Parsed_from_Kaggle_instances_json",
+                        "confidence": 1.0,
+                        "source_field": "licenseName",
+                    },
+                    "modelCategory": {
+                        "extraction_method": "Parsed_from_Kaggle_instances_json",
+                        "confidence": 1.0,
+                        "source_field": "frameworkName",
+                        "notes": "Framework read from the instance URL",
+                    },
+                    "baseModel": {
+                        "extraction_method": "Parsed_from_Kaggle_instances_json",
+                        "confidence": 1.0,
+                        "source_field": (
+                            "baseModelInstanceInformation, externalBaseModelUrl, "
+                            "parent_mlentory_id"
+                        ),
+                        "notes": (
+                            "Real lineage first, then the parent model this "
+                            "instance belongs to"
+                        ),
+                    },
+                    "usageInstructions": {
+                        "extraction_method": "Parsed_from_Kaggle_instances_json",
+                        "confidence": 1.0,
+                        "source_field": "usage",
+                    },
+                    "memoryRequirements": {
+                        "extraction_method": "Parsed_from_Kaggle_instances_json",
+                        "confidence": 1.0,
+                        "source_field": "totalUncompressedBytes",
+                    },
+                },
+            }
+
+            obj = MLModel(**payload)
+            normalized.append(obj.model_dump(mode="json", by_alias=True))
+
+        except ValidationError as ve:
+            errors.append(
+                {
+                    "instanceId": instance_id,
+                    "_index": idx,
+                    "_error": "MLModel validation failed",
+                    "details": ve.errors(),
+                }
+            )
+        except Exception as e:
+            errors.append(
+                {
+                    "instanceId": instance_id,
+                    "_index": idx,
+                    "_error": str(e),
+                    "error_type": type(e).__name__,
+                }
+            )
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(normalized, f, indent=2, ensure_ascii=False, default=_json_default)
+
+    if errors:
+        err_path = Path(normalized_folder) / "mlinstances_normalization_errors.json"
+        with open(err_path, "w", encoding="utf-8") as f:
+            json.dump(errors, f, indent=2, ensure_ascii=False)
+        logger.warning(
+            "Normalized %d/%d instances. Errors: %d (see %s)",
+            len(normalized), len(raw_instances), len(errors), err_path,
+        )
+    else:
+        logger.info("Normalized %d/%d instances. No errors.", len(normalized), len(raw_instances))
+
+    return str(out_path)
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={
+        "keywords_data": AssetIn("kaggle_keywords_raw"),
+        "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_keywords_normalized(
+    keywords_data: Tuple[str, str],
+    run_folder_data: Tuple[str, str],
+) -> str:
+    """
+    Normalize Kaggle keywords to schema.org DefinedTerm-like format and write
+    <normalized_folder>/keywords.json with IRI keys.
+    """
+    keywords_json_path, _raw_run_folder = keywords_data
+    _raw_models_json_path, normalized_folder = run_folder_data
+
+    out_path = Path(normalized_folder) / "keywords.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not keywords_json_path:
+        logger.info("No keywords_json_path. Writing empty keywords.json")
+        out_path.write_text("[]", encoding="utf-8")
+        return str(out_path)
+
+    raw_keywords = _load_json_records(keywords_json_path)
+    logger.info("Loading Kaggle keywords from %s (%d records)", keywords_json_path, len(raw_keywords))
+
+    normalized: List[Dict[str, Any]] = []
+    errors: List[Dict[str, Any]] = []
+
+    for idx, rec in enumerate(raw_keywords):
+        name = str(rec.get("name", "")).strip() or f"keyword_{idx}"
+        mlentory_id = str(rec.get("mlentory_id", "")).strip() or None
+
+        identifiers: List[str] = []
+        if mlentory_id:
+            identifiers.append(mlentory_id)
+
+        extraction_meta = rec.get("extraction_metadata") or {}
+        if not isinstance(extraction_meta, dict):
+            extraction_meta = {}
+
+        # Kaggle groups its tags under a category prefix in fullPath
+        # ("analysis > nlp"), which is the vocabulary the term belongs to.
+        category = str(rec.get("category", "")).strip()
+
+        payload: Dict[str, Any] = {
+            "identifier": identifiers,
+            "name": name,
+            "url": None,
+            "term_code": name,
+            "description": str(rec.get("description", "")).strip() or None,
+            "extraction_metadata": extraction_meta,
+        }
+        if category:
+            payload["in_defined_term_set"] = [category]
+
+        try:
+            obj = DefinedTerm(**payload)
+            normalized.append(obj.model_dump(mode="json", by_alias=True))
+        except ValidationError as ve:
+            errors.append(
+                {
+                    "keyword": name,
+                    "_index": idx,
+                    "_error": "DefinedTerm validation failed",
+                    "details": ve.errors(),
+                }
+            )
+        except Exception as e:
+            errors.append(
+                {
+                    "keyword": name,
+                    "_index": idx,
+                    "_error": str(e),
+                    "error_type": type(e).__name__,
+                }
+            )
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(normalized, f, indent=2, ensure_ascii=False)
+
+    if errors:
+        err_path = Path(normalized_folder) / "keywords_normalization_errors.json"
+        with open(err_path, "w", encoding="utf-8") as f:
+            json.dump(errors, f, indent=2, ensure_ascii=False)
+        logger.warning(
+            "Normalized %d/%d keywords. Errors: %d (see %s)",
+            len(normalized), len(raw_keywords), len(errors), err_path,
+        )
+    else:
+        logger.info("Normalized %d/%d keywords. No errors.", len(normalized), len(raw_keywords))
+
+    return str(out_path)
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={
+        "frameworks_data": AssetIn("kaggle_frameworks_raw"),
+        "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_frameworks_normalized(
+    frameworks_data: Tuple[str, str],
+    run_folder_data: Tuple[str, str],
+) -> str:
+    """
+    Normalize Kaggle frameworks to schema.org DefinedTerm-like format and write
+    <normalized_folder>/frameworks.json with IRI keys.
+    """
+    frameworks_json_path, _raw_run_folder = frameworks_data
+    _raw_models_json_path, normalized_folder = run_folder_data
+
+    out_path = Path(normalized_folder) / "frameworks.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not frameworks_json_path:
+        logger.info("No frameworks_json_path. Writing empty frameworks.json")
+        out_path.write_text("[]", encoding="utf-8")
+        return str(out_path)
+
+    raw_frameworks = _load_json_records(frameworks_json_path)
+    logger.info(
+        "Loading Kaggle frameworks from %s (%d records)", frameworks_json_path, len(raw_frameworks)
+    )
+
+    normalized: List[Dict[str, Any]] = []
+    errors: List[Dict[str, Any]] = []
+
+    for idx, rec in enumerate(raw_frameworks):
+        name = str(rec.get("name", "")).strip() or f"framework_{idx}"
+        mlentory_id = str(rec.get("mlentory_id", "")).strip() or None
+
+        extraction_meta = rec.get("extraction_metadata") or {}
+        if not isinstance(extraction_meta, dict):
+            extraction_meta = {}
+
+        payload: Dict[str, Any] = {
+            "identifier": [mlentory_id] if mlentory_id else [],
+            "name": name,
+            "url": None,
+            "term_code": name,
+            "description": "Framework a Kaggle model instance ships in.",
+            "in_defined_term_set": ["https://www.kaggle.com/models"],
+            "extraction_metadata": extraction_meta,
+        }
+
+        try:
+            obj = DefinedTerm(**payload)
+            normalized.append(obj.model_dump(mode="json", by_alias=True))
+        except ValidationError as ve:
+            errors.append(
+                {
+                    "framework": name,
+                    "_index": idx,
+                    "_error": "DefinedTerm validation failed",
+                    "details": ve.errors(),
+                }
+            )
+        except Exception as e:
+            errors.append(
+                {
+                    "framework": name,
+                    "_index": idx,
+                    "_error": str(e),
+                    "error_type": type(e).__name__,
+                }
+            )
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(normalized, f, indent=2, ensure_ascii=False)
+
+    if errors:
+        err_path = Path(normalized_folder) / "frameworks_normalization_errors.json"
+        with open(err_path, "w", encoding="utf-8") as f:
+            json.dump(errors, f, indent=2, ensure_ascii=False)
+        logger.warning(
+            "Normalized %d/%d frameworks. Errors: %d (see %s)",
+            len(normalized), len(raw_frameworks), len(errors), err_path,
+        )
+    else:
+        logger.info("Normalized %d/%d frameworks. No errors.", len(normalized), len(raw_frameworks))
+
+    return str(out_path)
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={
+        "licenses_data": AssetIn("kaggle_licenses_raw"),
+        "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_licenses_normalized(
+    licenses_data: Tuple[str, str],
+    run_folder_data: Tuple[str, str],
+) -> str:
+    """
+    Normalize Kaggle licenses into the schema.org-style output (IRI keys).
+
+    Output file: <normalized_folder>/licenses.json
+    """
+    licenses_json_path, _raw_run_folder = licenses_data
+    _raw_models_json_path, normalized_folder = run_folder_data
+
+    out_path = Path(normalized_folder) / "licenses.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not licenses_json_path:
+        logger.info("No licenses_json_path provided. Writing empty licenses.json")
+        out_path.write_text("[]", encoding="utf-8")
+        return str(out_path)
+
+    raw_licenses = _load_json_records(licenses_json_path)
+    logger.info("Loading Kaggle licenses from %s (%d records)", licenses_json_path, len(raw_licenses))
+
+    normalized: List[Dict[str, Any]] = []
+    errors: List[Dict[str, Any]] = []
+
+    for idx, rec in enumerate(raw_licenses):
+        name = str(rec.get("name", "")).strip()
+        mlentory_id = str(rec.get("mlentory_id", "")).strip()
+
+        if not name or not mlentory_id:
+            errors.append(
+                {
+                    "_index": idx,
+                    "_error": "missing required fields",
+                    "name": name,
+                    "mlentory_id": mlentory_id,
+                }
+            )
+            continue
+
+        em = rec.get("extraction_metadata") or {}
+        if not isinstance(em, dict):
+            em = {}
+
+        # Kaggle reports a bare license name with no SPDX identifier or url,
+        # so the SPDX-shaped fields stay None.
+        meta_out = {
+            "extraction_method": em.get("extraction_method"),
+            "confidence": em.get("confidence", 1.0),
+            "source_identifier": em.get("source_identifier"),
+            "source_name": em.get("source_name", name),
+            "osi_approved": em.get("osi_approved"),
+            "deprecated": em.get("deprecated"),
+        }
+
+        normalized.append(
+            {
+                "https://schema.org/identifier": [mlentory_id],
+                "https://schema.org/name": name,
+                "https://schema.org/url": None,
+                "https://schema.org/sameAs": [],
+                "https://schema.org/alternateName": [],
+                "https://schema.org/description": None,
+                "https://schema.org/abstract": None,
+                "https://schema.org/text": None,
+                "https://schema.org/license": None,
+                "https://schema.org/version": None,
+                "https://schema.org/copyrightNotice": None,
+                "https://schema.org/legislationJurisdiction": None,
+                "https://schema.org/legislationType": None,
+                "https://schema.org/dateCreated": None,
+                "https://schema.org/dateModified": None,
+                "https://schema.org/datePublished": None,
+                "https://schema.org/isBasedOn": [],
+                "https://schema.org/subjectOf": [],
+                "https://w3id.org/mlentory/mlentory_graph/meta/": meta_out,
+            }
+        )
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(normalized, f, indent=2, ensure_ascii=False)
+
+    if errors:
+        err_path = Path(normalized_folder) / "licenses_normalization_errors.json"
+        with open(err_path, "w", encoding="utf-8") as f:
+            json.dump(errors, f, indent=2, ensure_ascii=False)
+        logger.warning(
+            "Normalized %d/%d licenses. Errors written to %s",
+            len(normalized), len(raw_licenses), err_path,
+        )
+    else:
+        logger.info("Normalized %d/%d licenses", len(normalized), len(raw_licenses))
+
+    logger.info("Wrote normalized licenses to %s", out_path)
+    return str(out_path)
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={
+        "keywords_json": AssetIn("kaggle_keywords_normalized"),
+        "licenses_json": AssetIn("kaggle_licenses_normalized"),
+        "frameworks_json": AssetIn("kaggle_frameworks_normalized"),
+        "models_json": AssetIn("kaggle_model_normalized"),
+        "instances_json": AssetIn("kaggle_instances_normalized"),
+        "sources_json": AssetIn("kaggle_sources_normalized"),
+        "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_create_translation_mapping(
+    keywords_json: str,
+    licenses_json: str,
+    frameworks_json: str,
+    models_json: str,
+    instances_json: str,
+    sources_json: str,
+    run_folder_data: Tuple[str, str],
+) -> str:
+    """
+    Create translation mapping: MLentory URI -> human-readable name.
+
+    Reads normalized Kaggle entity JSON files and extracts:
+      - MLentory URI from https://schema.org/identifier (first mlentory_graph URI)
+      - Name from https://schema.org/name
+
+    Writes:
+      <normalized_folder>/translation_mapping.json
+    """
+    _, normalized_folder = run_folder_data
+
+    uri_prefix = "https://w3id.org/mlentory/mlentory_graph/"
+    out_map: Dict[str, str] = {}
+
+    def _first_non_empty(*values: Any) -> Optional[str]:
+        for v in values:
+            if v is None:
+                continue
+            s = str(v).strip()
+            if s:
+                return s
+        return None
+
+    def _extract_uri(record: Dict[str, Any]) -> Optional[str]:
+        ids = record.get("https://schema.org/identifier")
+        if not isinstance(ids, list):
+            return None
+        for cand in ids:
+            if isinstance(cand, str) and cand.startswith(uri_prefix):
+                return cand.strip()
+        return None
+
+    def _extract_name(record: Dict[str, Any]) -> Optional[str]:
+        return _first_non_empty(record.get("https://schema.org/name"))
+
+    entity_configs = [
+        {"label": "keywords", "path": keywords_json},
+        {"label": "licenses", "path": licenses_json},
+        {"label": "frameworks", "path": frameworks_json},
+        {"label": "models", "path": models_json},
+        {"label": "instances", "path": instances_json},
+        {"label": "sources", "path": sources_json},
+    ]
+
+    for cfg in entity_configs:
+        records = _load_json_records(cfg["path"])
+        if not records:
+            continue
+
+        for rec in records:
+            uri = _extract_uri(rec)
+            if not uri:
+                continue
+            name = _extract_name(rec)
+            if not name:
+                continue
+
+            out_map[uri] = name
+
+    output_path = Path(normalized_folder) / "translation_mapping.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(out_map, f, indent=2, ensure_ascii=False)
+
+    logger.info("Saved translation mapping (%d entries) to %s", len(out_map), output_path)
+    return str(output_path)

--- a/etl/assets/kaggle_transformation.py
+++ b/etl/assets/kaggle_transformation.py
@@ -92,6 +92,153 @@ def _clean_framework(framework: str) -> str:
     return "".join(p.capitalize() for p in parts)
 
 
+
+def _adaption_technique(record: Dict[str, Any]) -> Optional[str]:
+    """
+    Return ``"fineTuned"`` when the instance carries Kaggle's ``fineTunable``
+    flag, else ``None``.
+
+    Note this is Kaggle's own field and it is set on most instances, so most
+    records will come out as fineTuned.
+    """
+    if record.get("fineTunable"):
+        return "fineTuned"
+    return None
+
+
+def normalize_kaggle_instance(rec: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Map one Kaggle model instance onto the MLModel field set.
+
+    An instance is a downloadable artifact of a model - one per framework and
+    variation - and is emitted as an MLModel in its own right, alongside the
+    models themselves. Only the fields it genuinely owns are mapped: its own
+    name, overview, usage snippet, license, size and URL.
+
+    ``baseModel`` carries two kinds of link, real lineage first: the model an
+    instance was derived from (from ``baseModelInstanceInformation``), then
+    the parent model it belongs to. Both become ``fair4ml:baseModel`` edges,
+    which gives the graph a parent node with its variations as children.
+    """
+    instance_id = str(rec.get("instanceId", "")).strip()
+    mlentory_id = str(rec.get("mlentory_id", "")).strip()
+    parent_id = str(rec.get("parent_mlentory_id", "")).strip()
+    url = str(rec.get("url", "")).strip()
+
+    identifiers = [x for x in (mlentory_id,) if x]
+    urls = [x for x in (url,) if x]
+    if mlentory_id.startswith("https://w3id.org/mlentory/"):
+        urls.append(
+            mlentory_id.replace(
+                "https://w3id.org/mlentory/", "https://mlentory.zbmed.de/", 1
+            )
+        )
+
+    # Real lineage: base model reconstructed from the nested
+    # baseModelInstanceInformation object. The framework there uses the field
+    # spelling ("pyTorch"), so it is normalized to the URL form the instance
+    # ids are built from, or the hash would not match.
+    base_models: List[str] = []
+    base_info = rec.get("baseModelInstanceInformation")
+    if isinstance(base_info, str) and base_info.strip():
+        try:
+            base_info = json.loads(base_info)
+        except (ValueError, TypeError):
+            base_info = None
+    if isinstance(base_info, dict):
+        owner = base_info.get("owner")
+        owner_slug = ""
+        if isinstance(owner, dict):
+            owner_slug = str(owner.get("slug", "")).strip()
+        model_slug = str(base_info.get("modelSlug", "")).strip()
+        instance_slug = str(base_info.get("instanceSlug", "")).strip()
+        framework = _clean_framework(str(base_info.get("framework", "")).strip())
+        parts = [p for p in (owner_slug, model_slug, framework, instance_slug) if p]
+        if len(parts) == 4:
+            base_models.append(
+                KaggleHelper.generate_mlentory_entity_hash_id(
+                    "ModelInstance", "/".join(parts), platform="Kaggle"
+                )
+            )
+
+    external_base = str(rec.get("externalBaseModelUrl", "")).strip()
+    if external_base and external_base not in base_models:
+        base_models.append(external_base)
+
+    # The parent model this instance belongs to. Added last so real lineage
+    # stays at index 0 for anything that needs to tell the two apart.
+    if parent_id and parent_id not in base_models:
+        base_models.append(parent_id)
+
+    # The instance's own documentation. `overview` is the short summary Kaggle
+    # shows on the variation page; `usage` is the long form and is often
+    # richer than the parent model card. abstract holds both, matching what it
+    # means at model level: the complete original text for this record.
+    overview = str(rec.get("description", "")).strip()
+    usage = str(rec.get("usage", "")).strip()
+    full_card = "\n\n".join(part for part in (overview, usage) if part)
+
+    meta = {
+        "extraction_method": "Parsed_from_Kaggle_instances_json",
+        "confidence": 1.0,
+    }
+
+    return {
+        "identifier": identifiers,
+        "name": str(rec.get("name", "")).strip() or instance_id,
+        "url": list(dict.fromkeys(urls)),
+        "author": str(rec.get("sharedBy", "")).strip() or None,
+        "sharedBy": str(rec.get("sharedBy", "")).strip() or None,
+        "description": overview or None,
+        "abstract": full_card or None,
+        "license": str(rec.get("license", "")).strip() or None,
+        "modelCategory": [
+            x for x in (str(rec.get("frameworkName", "")).strip(),) if x
+        ],
+        "baseModel": base_models,
+        "adaptionTechniques": _adaption_technique(rec),
+        "usageInstructions": usage or None,
+        "memoryRequirements": str(rec.get("contentSize", "")).strip() or None,
+        "archivedAt": url or None,
+        "extraction_metadata": {
+            "identifier": {**meta, "source_field": "mlentory_id"},
+            "name": {**meta, "source_field": "slug"},
+            "sharedBy": {
+                **meta,
+                "source_field": "sharedBy",
+                "notes": "Owner carried down from the parent model",
+            },
+            "description": {**meta, "source_field": "overview"},
+            "abstract": {
+                **meta,
+                "source_field": "overview, usage",
+                "notes": "Full instance documentation before summarization",
+            },
+            "license": {**meta, "source_field": "licenseName"},
+            "modelCategory": {
+                **meta,
+                "source_field": "frameworkName",
+                "notes": "Framework read from the instance URL",
+            },
+            "baseModel": {
+                **meta,
+                "source_field": (
+                    "baseModelInstanceInformation, externalBaseModelUrl, "
+                    "parent_mlentory_id"
+                ),
+                "notes": "Real lineage first, then the parent model",
+            },
+            "adaptionTechniques": {
+                **meta,
+                "source_field": "fineTunable",
+            },
+            "usageInstructions": {**meta, "source_field": "usage"},
+            "memoryRequirements": {**meta, "source_field": "totalUncompressedBytes"},
+        },
+        "_model_id": instance_id,
+    }
+
+
 # ---------- normalized folder ----------
 
 @asset(
@@ -282,6 +429,7 @@ def kaggle_sources_normalized(run_folder_data: Tuple[str, str]) -> str:
         "keywords_mapping": AssetIn("kaggle_identified_keywords"),
         "licenses_mapping": AssetIn("kaggle_identified_licenses"),
         "frameworks_mapping": AssetIn("kaggle_identified_frameworks"),
+        "sharedby_mapping": AssetIn("kaggle_identified_sharedby"),
         "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
     },
     tags={"pipeline": "Kaggle_etl", "stage": "transform"},
@@ -290,6 +438,7 @@ def kaggle_entity_linking(
     keywords_mapping: Dict[str, List[str]],
     licenses_mapping: Dict[str, List[str]],
     frameworks_mapping: Dict[str, List[str]],
+    sharedby_mapping: Dict[str, List[str]],
     run_folder_data: Tuple[str, str],
 ) -> str:
     """
@@ -326,6 +475,7 @@ def kaggle_entity_linking(
         set(keywords_mapping.keys())
         | set(licenses_mapping.keys())
         | set(frameworks_mapping.keys())
+        | set(sharedby_mapping.keys())
     )
 
     entity_linking: Dict[str, Dict[str, List[str]]] = {}
@@ -334,6 +484,7 @@ def kaggle_entity_linking(
         keywords = keywords_mapping.get(model_id, []) or []
         licenses = licenses_mapping.get(model_id, []) or []
         frameworks = frameworks_mapping.get(model_id, []) or []
+        sharedby = sharedby_mapping.get(model_id, []) or []
 
         entity_linking[model_id] = {
             "keywords": [
@@ -347,6 +498,10 @@ def kaggle_entity_linking(
             "frameworks": [
                 KaggleHelper.generate_mlentory_entity_hash_id("Framework", x, platform="Kaggle")
                 for x in frameworks
+            ],
+            "sharedby": [
+                KaggleHelper.generate_mlentory_entity_hash_id("SharedBy", x, platform="Kaggle")
+                for x in sharedby
             ],
             "sources": list(kaggle_catalog_source_iris),
         }
@@ -386,6 +541,7 @@ def merge_kaggle_partial_schemas(
         keywords = links.get("keywords") or []
         licenses = links.get("licenses") or []
         frameworks = links.get("frameworks") or []
+        sharedby = links.get("sharedby") or []
         sources = links.get("sources") or []
         linked_fields: List[str] = []
 
@@ -404,6 +560,10 @@ def merge_kaggle_partial_schemas(
             # Frameworks replace the raw modelCategory strings with their IRIs
             merged_data["modelCategory"] = list(frameworks)
             linked_fields.append("modelCategory")
+
+        if sharedby:
+            merged_data["sharedBy"] = str(sharedby[0])  # MLModel.sharedBy is a single string
+            linked_fields.append("sharedBy")
 
         if sources:
             merged_data["source"] = str(sources[0])  # MLModel.source is a single string
@@ -434,6 +594,10 @@ def merge_kaggle_partial_schemas(
         iu = merged_data.get("intendedUse")
         if iu is not None and not isinstance(iu, str):
             merged_data["intendedUse"] = str(iu)
+
+        # Kaggle records lineage per instance, never on the model itself, so a
+        # parent model has no evidence it was adapted from anything.
+        merged_data.setdefault("adaptionTechniques", None)
 
         merged_items.append((model_id, merged_data))
 
@@ -486,6 +650,7 @@ def validate_kaggle_mlmodels(
         "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
         "basic_properties_path": AssetIn("kaggle_extract_basic_properties"),
         "entity_linking_path": AssetIn("kaggle_entity_linking"),
+        "instances_data": AssetIn("kaggle_instances_raw"),
     },
     tags={"pipeline": "Kaggle_etl", "stage": "transform"},
 )
@@ -493,14 +658,22 @@ def kaggle_model_normalized(
     run_folder_data: Tuple[str, str],
     basic_properties_path: str,
     entity_linking_path: str,
+    instances_data: Tuple[str, str],
 ) -> str:
     """
     Builds FAIR4ML-validated MLModel objects for Kaggle.
+
+    Both models and their instances land in ``mlmodels.json``. A Kaggle model
+    is a container and its instances are the downloadable artifacts - one per
+    framework and variation - and each is an MLModel in its own right. They
+    are distinguishable by ``baseModel``, which on an instance points at the
+    model it belongs to, and by ``adaptionTechniques``.
 
     Inputs:
       - run_folder_data: (raw_models_json_path, normalized_run_folder)
       - basic_properties_path: .../partial_basic_properties.json
       - entity_linking_path: .../entity_linking.json
+      - instances_data: (instances_json_path, raw_run_folder)
 
     Output:
       - .../mlmodels.json in the normalized_run_folder
@@ -571,10 +744,39 @@ def kaggle_model_normalized(
         all_model_ids=all_ids,
     )
 
+    # Instances are MLModels too, so they are validated and written into the
+    # same file rather than a separate one.
+    instances_json_path, _raw_run_folder = instances_data
+    raw_instances = _load_json_records(instances_json_path) if instances_json_path else []
+    logger.info("Loading %d Kaggle instances from %s", len(raw_instances), instances_json_path)
+
+    instance_items: List[Tuple[str, Dict[str, Any]]] = []
+    for rec in raw_instances:
+        mapped = normalize_kaggle_instance(rec)
+        instance_id = mapped.pop("_model_id", "") or f"instance_{len(instance_items)}"
+
+        # Entity linking only covers models.json, so an instance's sharedBy is
+        # still a plain name here. Mint the same IRI the models get, so both
+        # point at one shared node rather than a name and an IRI.
+        shared_by_name = str(mapped.get("sharedBy", "") or "").strip()
+        if shared_by_name:
+            mapped["sharedBy"] = KaggleHelper.generate_mlentory_entity_hash_id(
+                "SharedBy", shared_by_name, platform="Kaggle"
+            )
+
+        instance_items.append((instance_id, mapped))
+
+    merged_items.extend(instance_items)
+
     normalized_models, validation_errors = validate_kaggle_mlmodels(merged_items)
 
     if not normalized_models:
         raise RuntimeError("kaggle_model_normalized produced zero valid MLModels. Aborting run.")
+
+    logger.info(
+        "Normalized %d records (%d models + %d instances)",
+        len(normalized_models), len(all_ids), len(instance_items),
+    )
 
     output_path = normalized_folder_path / "mlmodels.json"
     with open(output_path, "w", encoding="utf-8") as f:
@@ -593,238 +795,6 @@ def kaggle_model_normalized(
 
     logger.info("Saved mlmodels.json to %s", output_path)
     return str(output_path)
-
-
-@asset(
-    group_name="kaggle_transformation",
-    ins={
-        "instances_data": AssetIn("kaggle_instances_raw"),
-        "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
-    },
-    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
-)
-def kaggle_instances_normalized(
-    instances_data: Tuple[str, str],
-    run_folder_data: Tuple[str, str],
-) -> str:
-    """
-    Normalize Kaggle model instances into FAIR4ML MLModel objects and write
-    <normalized_folder>/mlinstances.json.
-
-    An instance is a downloadable artifact of a model - one per framework and
-    variation - so only the fields it genuinely owns are mapped: its own name,
-    overview, usage snippet, license, size and URL.
-
-    ``baseModel`` carries two kinds of link, real lineage first: the model an
-    instance was derived from (from ``baseModelInstanceInformation``), then
-    the parent model it belongs to. Both land as ``fair4ml:baseModel`` edges,
-    which gives the graph a parent node with its variations as children -
-    "show me every variation of Gemma" - at the cost of not separating
-    "packaged from" from "derived from" in the predicate itself.
-    """
-    instances_json_path, _raw_run_folder = instances_data
-    _raw_models_json_path, normalized_folder = run_folder_data
-
-    out_path = Path(normalized_folder) / "mlinstances.json"
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-
-    if not instances_json_path:
-        logger.info("No instances_json_path. Writing empty mlinstances.json")
-        out_path.write_text("[]", encoding="utf-8")
-        return str(out_path)
-
-    raw_instances = _load_json_records(instances_json_path)
-    logger.info("Loading Kaggle instances from %s (%d records)", instances_json_path, len(raw_instances))
-
-    normalized: List[Dict[str, Any]] = []
-    errors: List[Dict[str, Any]] = []
-
-    for idx, rec in enumerate(raw_instances):
-        instance_id = str(rec.get("instanceId", "")).strip() or f"instance_{idx}"
-
-        try:
-            mlentory_id = str(rec.get("mlentory_id", "")).strip()
-            parent_id = str(rec.get("parent_mlentory_id", "")).strip()
-            url = str(rec.get("url", "")).strip()
-
-            identifiers = [x for x in (mlentory_id,) if x]
-            urls = [x for x in (url,) if x]
-            if mlentory_id.startswith("https://w3id.org/mlentory/"):
-                urls.append(
-                    mlentory_id.replace(
-                        "https://w3id.org/mlentory/", "https://mlentory.zbmed.de/", 1
-                    )
-                )
-
-            # Real lineage only: base model reconstructed from the nested
-            # baseModelInstanceInformation object. The framework there uses the
-            # field spelling ("pyTorch"), so it is normalized to the URL form
-            # the instance ids are built from, or the hash would not match.
-            base_models: List[str] = []
-            base_info = rec.get("baseModelInstanceInformation")
-            if isinstance(base_info, str) and base_info.strip():
-                try:
-                    base_info = json.loads(base_info)
-                except (ValueError, TypeError):
-                    base_info = None
-            if isinstance(base_info, dict):
-                owner = base_info.get("owner")
-                owner_slug = ""
-                if isinstance(owner, dict):
-                    owner_slug = str(owner.get("slug", "")).strip()
-                model_slug = str(base_info.get("modelSlug", "")).strip()
-                instance_slug = str(base_info.get("instanceSlug", "")).strip()
-                framework = _clean_framework(str(base_info.get("framework", "")).strip())
-                parts = [p for p in (owner_slug, model_slug, framework, instance_slug) if p]
-                if len(parts) == 4:
-                    base_ref = "/".join(parts)
-                    base_models.append(
-                        KaggleHelper.generate_mlentory_entity_hash_id(
-                            "ModelInstance", base_ref, platform="Kaggle"
-                        )
-                    )
-
-            external_base = str(rec.get("externalBaseModelUrl", "")).strip()
-            if external_base and external_base not in base_models:
-                base_models.append(external_base)
-
-            # The parent model this instance belongs to. Added last so real
-            # lineage stays at index 0 for anything that needs to tell the two
-            # apart. Without it 57 of 58 instances have no edges at all and sit
-            # orphaned in the graph, so an imprecise edge beats none: this is
-            # what makes "show every variation of Gemma" answerable.
-            #
-            # The precise fix is schema:isPartOf added to the mapped property
-            # list in rdf_loader.build_model_triples - one IRI in a shared
-            # file - which would separate "packaged from" from "derived from".
-            if parent_id and parent_id not in base_models:
-                base_models.append(parent_id)
-
-            # The instance's own documentation. `overview` is the short
-            # summary Kaggle shows on the variation page; `usage` is the long
-            # form - intended uses, sample code, limitations, training notes -
-            # and is often richer than the parent model card. abstract holds
-            # both, matching what it means at model level: the complete
-            # original text for this record.
-            overview = str(rec.get("description", "")).strip()
-            usage = str(rec.get("usage", "")).strip()
-            full_card = "\n\n".join(part for part in (overview, usage) if part)
-
-            payload: Dict[str, Any] = {
-                "identifier": identifiers,
-                "name": str(rec.get("name", "")).strip() or instance_id,
-                "url": list(dict.fromkeys(urls)),
-                "author": str(rec.get("parent_name", "")).strip() or None,
-                "description": overview or None,
-                "abstract": full_card or None,
-                "license": str(rec.get("license", "")).strip() or None,
-                "modelCategory": [
-                    x for x in (str(rec.get("frameworkName", "")).strip(),) if x
-                ],
-                "baseModel": base_models,
-                "usageInstructions": usage or None,
-                "memoryRequirements": str(rec.get("contentSize", "")).strip() or None,
-                "archivedAt": url or None,
-                "metrics": {
-                    "version": rec.get("version"),
-                    "fineTunable": rec.get("fineTunable"),
-                    "parentModel": parent_id,
-                },
-                "extraction_metadata": {
-                    "identifier": {
-                        "extraction_method": "Parsed_from_Kaggle_instances_json",
-                        "confidence": 1.0,
-                        "source_field": "mlentory_id",
-                    },
-                    "name": {
-                        "extraction_method": "Parsed_from_Kaggle_instances_json",
-                        "confidence": 1.0,
-                        "source_field": "slug",
-                    },
-                    "description": {
-                        "extraction_method": "Parsed_from_Kaggle_instances_json",
-                        "confidence": 1.0,
-                        "source_field": "overview",
-                    },
-                    "abstract": {
-                        "extraction_method": "Parsed_from_Kaggle_instances_json",
-                        "confidence": 1.0,
-                        "source_field": "overview, usage",
-                        "notes": "Full instance documentation before summarization",
-                    },
-                    "license": {
-                        "extraction_method": "Parsed_from_Kaggle_instances_json",
-                        "confidence": 1.0,
-                        "source_field": "licenseName",
-                    },
-                    "modelCategory": {
-                        "extraction_method": "Parsed_from_Kaggle_instances_json",
-                        "confidence": 1.0,
-                        "source_field": "frameworkName",
-                        "notes": "Framework read from the instance URL",
-                    },
-                    "baseModel": {
-                        "extraction_method": "Parsed_from_Kaggle_instances_json",
-                        "confidence": 1.0,
-                        "source_field": (
-                            "baseModelInstanceInformation, externalBaseModelUrl, "
-                            "parent_mlentory_id"
-                        ),
-                        "notes": (
-                            "Real lineage first, then the parent model this "
-                            "instance belongs to"
-                        ),
-                    },
-                    "usageInstructions": {
-                        "extraction_method": "Parsed_from_Kaggle_instances_json",
-                        "confidence": 1.0,
-                        "source_field": "usage",
-                    },
-                    "memoryRequirements": {
-                        "extraction_method": "Parsed_from_Kaggle_instances_json",
-                        "confidence": 1.0,
-                        "source_field": "totalUncompressedBytes",
-                    },
-                },
-            }
-
-            obj = MLModel(**payload)
-            normalized.append(obj.model_dump(mode="json", by_alias=True))
-
-        except ValidationError as ve:
-            errors.append(
-                {
-                    "instanceId": instance_id,
-                    "_index": idx,
-                    "_error": "MLModel validation failed",
-                    "details": ve.errors(),
-                }
-            )
-        except Exception as e:
-            errors.append(
-                {
-                    "instanceId": instance_id,
-                    "_index": idx,
-                    "_error": str(e),
-                    "error_type": type(e).__name__,
-                }
-            )
-
-    with open(out_path, "w", encoding="utf-8") as f:
-        json.dump(normalized, f, indent=2, ensure_ascii=False, default=_json_default)
-
-    if errors:
-        err_path = Path(normalized_folder) / "mlinstances_normalization_errors.json"
-        with open(err_path, "w", encoding="utf-8") as f:
-            json.dump(errors, f, indent=2, ensure_ascii=False)
-        logger.warning(
-            "Normalized %d/%d instances. Errors: %d (see %s)",
-            len(normalized), len(raw_instances), len(errors), err_path,
-        )
-    else:
-        logger.info("Normalized %d/%d instances. No errors.", len(normalized), len(raw_instances))
-
-    return str(out_path)
 
 
 @asset(
@@ -1130,8 +1100,8 @@ def kaggle_licenses_normalized(
         "keywords_json": AssetIn("kaggle_keywords_normalized"),
         "licenses_json": AssetIn("kaggle_licenses_normalized"),
         "frameworks_json": AssetIn("kaggle_frameworks_normalized"),
+        "sharedby_json": AssetIn("kaggle_sharedby_normalized"),
         "models_json": AssetIn("kaggle_model_normalized"),
-        "instances_json": AssetIn("kaggle_instances_normalized"),
         "sources_json": AssetIn("kaggle_sources_normalized"),
         "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
     },
@@ -1141,8 +1111,8 @@ def kaggle_create_translation_mapping(
     keywords_json: str,
     licenses_json: str,
     frameworks_json: str,
+    sharedby_json: str,
     models_json: str,
-    instances_json: str,
     sources_json: str,
     run_folder_data: Tuple[str, str],
 ) -> str:
@@ -1186,8 +1156,8 @@ def kaggle_create_translation_mapping(
         {"label": "keywords", "path": keywords_json},
         {"label": "licenses", "path": licenses_json},
         {"label": "frameworks", "path": frameworks_json},
+        {"label": "sharedby", "path": sharedby_json},
         {"label": "models", "path": models_json},
-        {"label": "instances", "path": instances_json},
         {"label": "sources", "path": sources_json},
     ]
 
@@ -1214,3 +1184,99 @@ def kaggle_create_translation_mapping(
 
     logger.info("Saved translation mapping (%d entries) to %s", len(out_map), output_path)
     return str(output_path)
+
+
+@asset(
+    group_name="kaggle_transformation",
+    ins={
+        "sharedby_data": AssetIn("kaggle_sharedby_raw"),
+        "run_folder_data": AssetIn("kaggle_normalized_model_folder"),
+    },
+    tags={"pipeline": "Kaggle_etl", "stage": "transform"},
+)
+def kaggle_sharedby_normalized(
+    sharedby_data: Tuple[str, str],
+    run_folder_data: Tuple[str, str],
+) -> str:
+    """
+    Normalize Kaggle sharedBy entities to schema.org DefinedTerm-like format
+    and write <normalized_folder>/sharedby.json with IRI keys.
+    """
+    sharedby_json_path, _raw_run_folder = sharedby_data
+    _raw_models_json_path, normalized_folder = run_folder_data
+
+    out_path = Path(normalized_folder) / "sharedby.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not sharedby_json_path:
+        logger.info("No sharedby_json_path. Writing empty sharedby.json")
+        out_path.write_text("[]", encoding="utf-8")
+        return str(out_path)
+
+    raw_sharedby = _load_json_records(sharedby_json_path)
+    logger.info(
+        "Loading Kaggle sharedBy entities from %s (%d records)",
+        sharedby_json_path, len(raw_sharedby),
+    )
+
+    normalized: List[Dict[str, Any]] = []
+    errors: List[Dict[str, Any]] = []
+
+    for idx, rec in enumerate(raw_sharedby):
+        name = str(rec.get("name", "")).strip() or f"sharedby_{idx}"
+        mlentory_id = str(rec.get("mlentory_id", "")).strip() or None
+
+        extraction_meta = rec.get("extraction_metadata") or {}
+        if not isinstance(extraction_meta, dict):
+            extraction_meta = {}
+
+        payload: Dict[str, Any] = {
+            "identifier": [mlentory_id] if mlentory_id else [],
+            "name": name,
+            "url": None,
+            "term_code": name,
+            "description": "Entity representing who shared/published the model.",
+            "in_defined_term_set": ["https://www.kaggle.com/models"],
+            "extraction_metadata": extraction_meta,
+        }
+
+        try:
+            obj = DefinedTerm(**payload)
+            normalized.append(obj.model_dump(mode="json", by_alias=True))
+        except ValidationError as ve:
+            errors.append(
+                {
+                    "sharedby": name,
+                    "_index": idx,
+                    "_error": "DefinedTerm validation failed",
+                    "details": ve.errors(),
+                }
+            )
+        except Exception as e:
+            errors.append(
+                {
+                    "sharedby": name,
+                    "_index": idx,
+                    "_error": str(e),
+                    "error_type": type(e).__name__,
+                }
+            )
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(normalized, f, indent=2, ensure_ascii=False)
+
+    if errors:
+        err_path = Path(normalized_folder) / "sharedby_normalization_errors.json"
+        with open(err_path, "w", encoding="utf-8") as f:
+            json.dump(errors, f, indent=2, ensure_ascii=False)
+        logger.warning(
+            "Normalized %d/%d sharedBy entities. Errors: %d (see %s)",
+            len(normalized), len(raw_sharedby), len(errors), err_path,
+        )
+    else:
+        logger.info(
+            "Normalized %d/%d sharedBy entities. No errors.",
+            len(normalized), len(raw_sharedby),
+        )
+
+    return str(out_path)

--- a/etl/config.py
+++ b/etl/config.py
@@ -59,6 +59,53 @@ class AI4LifeConfig(BaseModel):
     num_models: int = Field(default=50, ge=0)
     base_url: str = Field(default="https://hypha.aicell.io")
     parent_id: str = Field(default="bioimage-io/bioimage.io")
+    
+class KaggleConfig(BaseModel):
+    """Configuration for Kaggle model-card extraction."""
+
+    # --- Source ---
+    # Meta Kaggle CSVs are the source of truth for the model list. They
+    # refresh daily; refs are derived by joining Models -> owner (org or user).
+    meta_dataset: str = Field(default="kaggle/meta-kaggle")
+    refresh_metadata: bool = Field(
+        default=True,
+        description="Re-download Meta Kaggle CSVs to pick up new/changed models.",
+    )
+
+    # --- Scope ---
+    num_models: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Cap the number of models fetched. None = all (~42k).",
+    )
+    incremental: bool = Field(
+        default=True,
+        description=(
+            "Fetch only new/changed models since the last run. The full crawl "
+            "is a one-time baseline (~6h); deltas are ~1k models (~10 min)."
+        ),
+    )
+    force_full_refresh: bool = Field(
+        default=False,
+        description=(
+            "Refetch everything regardless of state. Catches description edits "
+            "that don't bump a date/version column in Meta Kaggle."
+        ),
+    )
+
+    # --- Concurrency ---
+    # Threads are cheap (the work is network-bound) but effective throughput
+    # is capped by Kaggle's quota, not by this value. See KaggleExtractor for
+    # the measured rate limits, which are deliberately not exposed here.
+    threads: int = Field(default=8, ge=1, le=32)
+
+    # --- Resilience ---
+    max_retries: int = Field(default=6, ge=1)
+    request_timeout_seconds: int = Field(default=30, ge=5)
+    checkpoint_every: int = Field(
+        default=200, ge=1,
+        description="Force records to disk every N records; bounds loss on crash.",
+    )
 
 
 class PlatformsConfig(BaseModel):
@@ -67,6 +114,7 @@ class PlatformsConfig(BaseModel):
     huggingface: HuggingFaceConfig = Field(default_factory=HuggingFaceConfig)
     openml: OpenMLConfig = Field(default_factory=OpenMLConfig)
     ai4life: AI4LifeConfig = Field(default_factory=AI4LifeConfig)
+    kaggle: KaggleConfig = Field(default_factory=KaggleConfig)
 
 
 class RunConfig(BaseModel):
@@ -185,6 +233,10 @@ def get_openml_config() -> OpenMLConfig:
 def get_ai4life_config() -> AI4LifeConfig:
     """Get AI4Life platform configuration."""
     return ConfigLoader.get_config().platforms.ai4life
+
+def get_kaggle_config() -> KaggleConfig:
+    """Get Kaggle platform configuration."""
+    return ConfigLoader.get_config().platforms.kaggle
 
 
 def get_general_config() -> GeneralConfig:

--- a/etl/repository.py
+++ b/etl/repository.py
@@ -14,6 +14,8 @@ from etl.assets import openml_extraction as openml_assets_module
 from etl.assets import ai4life_extraction as ai4life_assets_module
 from etl.assets import ai4life_transformation as ai4life_transformation_module
 from etl.assets import vector_indexing as vector_indexing_module
+from etl.assets import kaggle_extraction as kaggle_assets_module
+
 
 _ASSET_MODULES = [
     hf_extraction_module,
@@ -23,6 +25,7 @@ _ASSET_MODULES = [
     openml_assets_module,
     ai4life_assets_module,
     ai4life_transformation_module,
+    kaggle_assets_module,
     vector_indexing_module,
 ]
 

--- a/etl/repository.py
+++ b/etl/repository.py
@@ -15,6 +15,8 @@ from etl.assets import ai4life_extraction as ai4life_assets_module
 from etl.assets import ai4life_transformation as ai4life_transformation_module
 from etl.assets import vector_indexing as vector_indexing_module
 from etl.assets import kaggle_extraction as kaggle_assets_module
+from etl.assets import kaggle_transformation as kaggle_trasformation_module
+from etl.assets import kaggle_loading as kaggle_loading_module
 
 
 _ASSET_MODULES = [
@@ -26,6 +28,8 @@ _ASSET_MODULES = [
     ai4life_assets_module,
     ai4life_transformation_module,
     kaggle_assets_module,
+    kaggle_trasformation_module,
+    kaggle_loading_module,
     vector_indexing_module,
 ]
 

--- a/etl_extractors/kaggle/__init__.py
+++ b/etl_extractors/kaggle/__init__.py
@@ -1,0 +1,4 @@
+from .kaggle_extractor import KaggleExtractor
+# from .o_enrichment import OpenMLEnrichment
+
+__all__ = ["KaggleExtractor"]

--- a/etl_extractors/kaggle/clients/__init__.py
+++ b/etl_extractors/kaggle/clients/__init__.py
@@ -1,0 +1,9 @@
+from .models_client import KaggleModelClient
+from .instances_client import KaggleInstancesClient
+from .licenses_client import KaggleLicenseClient
+from .keywords_client import KaggleKeywordsClient
+from .frameworks_client import KaggleFrameworkClient
+from .sharedby_client import KaggleSharedByClient
+
+__all__ = ["KaggleModelClient", "KaggleInstancesClient", "KaggleLicenseClient", 
+           "KaggleKeywordsClient","KaggleFrameworkClient","KaggleSharedByClient"]

--- a/etl_extractors/kaggle/clients/__int__.py
+++ b/etl_extractors/kaggle/clients/__int__.py
@@ -1,0 +1,4 @@
+from .models_client import KaggleModelClient
+from .instances_client import KaggleInstancesClient
+
+__all__ = ["KaggleModelClient", "KaggleInstancesClient"]

--- a/etl_extractors/kaggle/clients/__int__.py
+++ b/etl_extractors/kaggle/clients/__int__.py
@@ -3,6 +3,7 @@ from .instances_client import KaggleInstancesClient
 from .licenses_client import KaggleLicenseClient
 from .keywords_client import KaggleKeywordsClient
 from .frameworks_client import KaggleFrameworkClient
+from .sharedby_client import KaggleSharedByClient
 
 __all__ = ["KaggleModelClient", "KaggleInstancesClient", "KaggleLicenseClient", 
-           "KaggleKeywordsClient","KaggleFrameworkClient"]
+           "KaggleKeywordsClient","KaggleFrameworkClient","KaggleSharedByClient"]

--- a/etl_extractors/kaggle/clients/__int__.py
+++ b/etl_extractors/kaggle/clients/__int__.py
@@ -1,4 +1,8 @@
 from .models_client import KaggleModelClient
 from .instances_client import KaggleInstancesClient
+from .licenses_client import KaggleLicenseClient
+from .keywords_client import KaggleKeywordsClient
+from .frameworks_client import KaggleFrameworkClient
 
-__all__ = ["KaggleModelClient", "KaggleInstancesClient"]
+__all__ = ["KaggleModelClient", "KaggleInstancesClient", "KaggleLicenseClient", 
+           "KaggleKeywordsClient","KaggleFrameworkClient"]

--- a/etl_extractors/kaggle/clients/frameworks_client.py
+++ b/etl_extractors/kaggle/clients/frameworks_client.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from etl_extractors.kaggle.kaggle_helper import KaggleHelper
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleFrameworkClient:
+    """
+    Client for interacting with Kaggle Model frameworks.
+
+    Kaggle reports a framework as a bare name on each model instance
+    ("PyTorch", "Keras", "TensorFlow2", "ScikitLearn", "Transformers") - there
+    is no id, version or url in the response - so a framework entity is the
+    name plus its minted ``mlentory_id``.
+
+    These are frameworks, not architectures: they describe the format an
+    instance ships in, not the model's design.
+    """
+
+    def __init__(self, records_data=None) -> None:
+        self.records_data = records_data or {}
+
+    def _extraction_time(self) -> str:
+        """
+        Extraction time in the run-folder format (``2026-01-30_05-03-47``).
+
+        ``records_data["timestamp"]`` is an ISO string set at fetch, so it is
+        reformatted here to match the convention used by the other platforms.
+        """
+        raw = str(self.records_data.get("timestamp", "") or "").strip()
+        if not raw:
+            return datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
+        try:
+            return datetime.fromisoformat(
+                raw.replace("Z", "+00:00")
+            ).strftime("%Y-%m-%d_%H-%M-%S")
+        except ValueError:
+            return raw
+
+    def get_frameworks_metadata(self, framework_names: List[str]) -> pd.DataFrame:
+        # make unique + deterministic
+        framework_names = sorted(
+            {str(x).strip() for x in framework_names if x and str(x).strip()}
+        )
+        extraction_time = self._extraction_time()
+
+        all_framework_data: List[Dict[str, Any]] = []
+
+        for framework_name in framework_names:
+            framework_data: Dict[str, Any] = {
+                "frameworkId": framework_name,
+                "mlentory_id": KaggleHelper.generate_mlentory_entity_hash_id(
+                    "Framework", framework_name, platform="Kaggle"
+                ),
+                "name": framework_name,
+                "enriched": True,
+                "entity_type": "Framework",
+                "platform": "Kaggle",
+                "extraction_metadata": {
+                    "extraction_method": "Kaggle_models_endpoint",
+                    "confidence": 1.0,
+                    "extraction_time": extraction_time,
+                },
+            }
+            all_framework_data.append(framework_data)
+
+        logger.info("Extracted %d distinct frameworks", len(all_framework_data))
+        return pd.DataFrame(all_framework_data)

--- a/etl_extractors/kaggle/clients/instances_client.py
+++ b/etl_extractors/kaggle/clients/instances_client.py
@@ -114,6 +114,10 @@ class KaggleInstancesClient:
         # parent's model card, not just their own short overview.
         parent_description = self._to_str((record or {}).get("description", ""))
         parent_title = self._to_str((record or {}).get("title", ""))
+        # The uploader is declared once on the model. Instances have no owner
+        # of their own, so it is carried down: a search for everything an
+        # account published should return their variations too.
+        parent_shared_by = self._to_str((record or {}).get("author", ""))
 
         raw_instances = record.get("instances")
         raw_instances = raw_instances if isinstance(raw_instances, list) else []
@@ -171,6 +175,7 @@ class KaggleInstancesClient:
             out["modelId"] = model_ref
             out["parent_name"] = parent_title
             out["parent_description"] = parent_description
+            out["sharedBy"] = parent_shared_by
             out["extraction_timestamp"] = self._to_str(
                 self.records_data.get("timestamp", "")
             )

--- a/etl_extractors/kaggle/clients/instances_client.py
+++ b/etl_extractors/kaggle/clients/instances_client.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from etl_extractors.kaggle.kaggle_helper import KaggleHelper
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleInstancesClient:
+    """Extractor for model instance metadata from the Kaggle platform.
+
+    A Kaggle model is a container: the downloadable artifacts are its
+    *instances*, one per framework and variation. ``Microsoft/phi-3`` has
+    three (pyTorch/mini, pyTorch/moe, keras/vision), each with its own
+    license, version, size and URL. Flattening them onto the model row would
+    lose which framework belongs to which variation, so they are emitted as
+    their own entities linked back by ``parent_mlentory_id``.
+    """
+
+    def __init__(self, records_data: Dict[str, Any]):
+        # expected: {"data": [...], "timestamp": "..."}
+        self.records_data = records_data or {}
+
+    def get_instances_metadata(self, instance_ids=None) -> pd.DataFrame:
+        """
+        Flatten model instances into one row per instance.
+
+        Args:
+            instance_ids: Optional iterable of instance ids to keep. When
+                omitted, every instance found is returned.
+        """
+        records = self.records_data.get("data", []) or []
+        model_records = [r for r in records if isinstance(r, dict)]
+
+        wanted = set(instance_ids) if instance_ids is not None else None
+
+        instances_metadata: List[Dict[str, Any]] = []
+        for model_record in model_records:
+            for row in self.fetch_instances_metadata(model_record):
+                if wanted is None or row["instanceId"] in wanted:
+                    instances_metadata.append(row)
+
+        logger.info(
+            "Extracted %d instances from %d models",
+            len(instances_metadata), len(model_records),
+        )
+        return pd.DataFrame(instances_metadata)
+
+    # ---------- helpers for normalization ----------
+
+    @staticmethod
+    def _to_str(value: Any) -> str:
+        """Convert any value to string; missing/None becomes empty string."""
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, dict)):
+            return json.dumps(value, ensure_ascii=False)
+        return str(value)
+
+    @staticmethod
+    def _clean_framework(framework: str) -> str:
+        """
+        Turn Kaggle's framework enum into the form used in instance URLs.
+
+        ``MODEL_FRAMEWORK_TENSOR_FLOW_2`` -> ``TensorFlow2``. Only used when an
+        instance has no URL to read the display name from; the URL is
+        authoritative whenever it is present.
+        """
+        if not framework:
+            return ""
+        name = framework
+        if name.startswith("MODEL_FRAMEWORK_"):
+            name = name[len("MODEL_FRAMEWORK_"):]
+        parts = [p for p in name.split("_") if p]
+        return "".join(p.capitalize() for p in parts)
+
+    def fetch_instances_metadata(self, record: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Normalize all instances of a single model, missing values as ''."""
+        model_ref = self._to_str((record or {}).get("ref", ""))
+        if not model_ref:
+            return []
+
+        parent_id = KaggleHelper.generate_mlentory_entity_hash_id(
+            "Model", model_ref, platform="Kaggle"
+        )
+        # Carried onto every instance row so instances are searchable on their
+        # parent's model card, not just their own short overview.
+        parent_description = self._to_str((record or {}).get("description", ""))
+        parent_title = self._to_str((record or {}).get("title", ""))
+
+        raw_instances = record.get("instances")
+        raw_instances = raw_instances if isinstance(raw_instances, list) else []
+
+        out_rows: List[Dict[str, Any]] = []
+        for position, instance in enumerate(raw_instances):
+            if not isinstance(instance, dict):
+                continue
+
+            framework = self._to_str(instance.get("framework", ""))
+            variation = self._to_str(instance.get("slug", ""))
+            instance_url = self._to_str(instance.get("url", ""))
+
+            # Instance id mirrors the Kaggle URL path so it round-trips:
+            # owner/model/framework/variation
+            #
+            # Derive it from the URL when present rather than from the
+            # `framework` field: Kaggle capitalises them differently
+            # ("PyTorch" in the URL vs "pyTorch" in the field), and the
+            # identifier reads URLs, so both sides must agree.
+            marker = "/models/"
+            if instance_url and marker in instance_url:
+                instance_ref = instance_url.split(marker, 1)[1].strip("/")
+            else:
+                # No URL: fall back to the enum, cleaned into the display form
+                # Kaggle uses in URLs, so ids stay consistent either way.
+                instance_ref = "/".join(
+                    part for part in
+                    (model_ref, self._clean_framework(framework), variation) if part
+                )
+
+            # The URL's third segment is the display framework name
+            # ("TensorFlow2") as opposed to the enum in the `framework` field.
+            ref_parts = instance_ref.split("/")
+            framework_display = ref_parts[2] if len(ref_parts) >= 3 else framework
+
+            out: Dict[str, Any] = {}
+
+            # ---- pass through every raw instance field ----
+            # Kaggle may add fields at any time, and a curated subset would
+            # silently drop them. Raw keys land first so the derived schema
+            # fields below win on any name collision.
+            for raw_key, raw_value in instance.items():
+                if isinstance(raw_value, bool):
+                    out[raw_key] = raw_value
+                else:
+                    out[raw_key] = self._to_str(raw_value)
+
+            # ---- identity ----
+            out["instanceId"] = instance_ref
+            out["mlentory_id"] = KaggleHelper.generate_mlentory_entity_hash_id(
+                "ModelInstance", instance_ref, platform="Kaggle"
+            )
+            out["parent_mlentory_id"] = parent_id
+            out["modelId"] = model_ref
+            out["parent_name"] = parent_title
+            out["parent_description"] = parent_description
+            out["extraction_timestamp"] = self._to_str(
+                self.records_data.get("timestamp", "")
+            )
+            out["enriched"] = True
+            out["entity_type"] = "ModelInstance"
+            out["platform"] = "Kaggle"
+            out["position"] = position
+
+            # ---- schema-aligned fields ----
+            out["slug"] = variation
+            out["name"] = variation
+            out["description"] = self._to_str(instance.get("overview", ""))
+            out["modelArchitecture"] = framework
+            # Kaggle reports framework as an enum ("MODEL_FRAMEWORK_TENSOR_FLOW_2")
+            # but uses a display form in the URL ("TensorFlow2"). Keep both:
+            # the enum is faithful to the API, the display form is searchable.
+            out["frameworkName"] = framework_display
+            out["license"] = self._to_str(instance.get("licenseName", ""))
+            out["version"] = self._to_str(instance.get("versionNumber", ""))
+            out["url"] = instance_url
+            out["usage"] = self._to_str(instance.get("usage", ""))
+
+            # contentSize: bytes, kept numeric-as-string for consistency
+            size = instance.get("totalUncompressedBytes")
+            out["contentSize"] = self._to_str(size) if isinstance(size, (int, float)) else ""
+
+            # booleans kept as-is; downstream can coerce
+            out["fineTunable"] = bool(instance.get("fineTunable", False))
+            out["hasBaseModelInstanceInformation"] = bool(
+                instance.get("hasBaseModelInstanceInformation", False)
+            )
+
+            # trainingData is a list per instance
+            training = instance.get("trainingData")
+            if isinstance(training, list):
+                cleaned = [str(t) for t in training if t]
+            elif training:
+                cleaned = [str(training)]
+            else:
+                cleaned = []
+            out["trainedOn"] = json.dumps(cleaned, ensure_ascii=False) if cleaned else ""
+
+            # enforce: everything missing -> ""
+            for key, value in list(out.items()):
+                if value is None:
+                    out[key] = ""
+                elif isinstance(value, (list, dict)):
+                    out[key] = json.dumps(value, ensure_ascii=False)
+
+            out_rows.append(out)
+
+        return out_rows

--- a/etl_extractors/kaggle/clients/instances_client.py
+++ b/etl_extractors/kaggle/clients/instances_client.py
@@ -65,6 +65,26 @@ class KaggleInstancesClient:
         return str(value)
 
     @staticmethod
+    def _display_name(variation: str, parent_title: str, framework: str) -> str:
+        """
+        Build a name that identifies the instance on its own.
+
+        Kaggle names the sole variation of a model "default", so that slug
+        carries no information. Anything else is a real variation name and is
+        used as-is.
+        """
+        generic = {"default", "", "1"}
+        if variation.lower() not in generic:
+            return variation
+
+        parts = [p for p in (parent_title, framework) if p]
+        if len(parts) == 2:
+            return f"{parts[0]} ({parts[1]})"
+        if parts:
+            return parts[0]
+        return variation
+
+    @staticmethod
     def _clean_framework(framework: str) -> str:
         """
         Turn Kaggle's framework enum into the form used in instance URLs.
@@ -161,7 +181,12 @@ class KaggleInstancesClient:
 
             # ---- schema-aligned fields ----
             out["slug"] = variation
-            out["name"] = variation
+            # A single-variation model always uses the slug "default", so the
+            # slug alone is not a usable display name - a catalog would show
+            # dozens of identical "default" entries with no way to tell them
+            # apart. Fall back to the parent title plus framework, keeping the
+            # real slug in the `slug` field.
+            out["name"] = self._display_name(variation, parent_title, framework_display)
             out["description"] = self._to_str(instance.get("overview", ""))
             out["modelArchitecture"] = framework
             # Kaggle reports framework as an enum ("MODEL_FRAMEWORK_TENSOR_FLOW_2")

--- a/etl_extractors/kaggle/clients/keywords_client.py
+++ b/etl_extractors/kaggle/clients/keywords_client.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+import pandas as pd
+
+from etl_extractors.kaggle.kaggle_helper import KaggleHelper
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleKeywordsClient:
+    """Extractor for keyword (tag) metadata from the Kaggle platform.
+
+    Kaggle curates its tags, so each carries a stable ``ref``, a human
+    description and a ``fullPath`` placing it in a taxonomy
+    ("analysis > nlp", "task > classification", "technique > random forest",
+    "packages > sklearn"). The same tag object repeats identically on every
+    model that uses it, so keywords are de-duplicated by ``ref``: one node,
+    many edges.
+    """
+
+    def __init__(self, records_data: Dict[str, Any]):
+        # expected: {"data": [...], "timestamp": "..."}
+        self.records_data = records_data or {}
+
+    def get_keywords_metadata(
+        self, keyword_names: Optional[Iterable[str]] = None
+    ) -> pd.DataFrame:
+        """
+        Build one row per distinct keyword found across all models.
+
+        Args:
+            keyword_names: Optional refs to keep. When omitted, every keyword
+                found is returned.
+        """
+        records = self.records_data.get("data", []) or []
+        wanted = {str(k) for k in keyword_names} if keyword_names is not None else None
+
+        by_ref: Dict[str, Dict[str, Any]] = {}
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            for tag in self._tags_of(record):
+                ref = str(tag.get("ref") or tag.get("name") or "").strip()
+                if not ref or (wanted is not None and ref not in wanted):
+                    continue
+                # Later copies carry the same content; keep the first but let
+                # a richer one (with a description) win.
+                existing = by_ref.get(ref)
+                if existing is None or (
+                    not existing.get("description") and tag.get("description")
+                ):
+                    by_ref[ref] = tag
+
+        keywords_metadata = [
+            self.fetch_keyword_metadata(ref, tag) for ref, tag in sorted(by_ref.items())
+        ]
+        logger.info(
+            "Extracted %d distinct keywords from %d models",
+            len(keywords_metadata), len(records),
+        )
+        return pd.DataFrame(keywords_metadata)
+
+    # ---------- helpers for normalization ----------
+
+    def _extraction_time(self) -> str:
+        """
+        Extraction time in the run-folder format (``2026-01-30_05-03-47``).
+
+        ``records_data["timestamp"]`` is an ISO string set at fetch, so it is
+        reformatted here to match the convention used by the other platforms.
+        """
+        raw = str(self.records_data.get("timestamp", "") or "").strip()
+        if not raw:
+            return datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
+        try:
+            return datetime.fromisoformat(
+                raw.replace("Z", "+00:00")
+            ).strftime("%Y-%m-%d_%H-%M-%S")
+        except ValueError:
+            return raw
+
+    @staticmethod
+    def _to_str(value: Any) -> str:
+        """Convert any value to string; missing/None becomes empty string."""
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, dict)):
+            return json.dumps(value, ensure_ascii=False)
+        return str(value)
+
+    @staticmethod
+    def _tags_of(record: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Read the tag list off a raw record, tolerating a JSON-string form."""
+        tags = record.get("tags")
+        if isinstance(tags, str):
+            try:
+                tags = json.loads(tags)
+            except (ValueError, TypeError):
+                return []
+        if not isinstance(tags, list):
+            return []
+        return [t for t in tags if isinstance(t, dict)]
+
+    @staticmethod
+    def _split_full_path(full_path: str) -> tuple[str, str]:
+        """
+        Split "analysis > nlp" into ("analysis", "nlp").
+
+        The prefix is Kaggle's own grouping - task, analysis, technique,
+        packages - and makes a useful facet above the keyword itself.
+        """
+        if not full_path or ">" not in full_path:
+            return "", full_path.strip()
+        head, _, tail = full_path.rpartition(">")
+        return head.strip(), tail.strip()
+
+    def fetch_keyword_metadata(self, ref: str, tag: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize a single keyword, missing values as ''."""
+        out: Dict[str, Any] = {}
+
+        # fullPath places the tag in Kaggle's taxonomy ("analysis > nlp",
+        # "task > classification"). Only the category prefix is kept: it is
+        # what distinguishes kinds of tag - a task from a technique from a
+        # package - and the leaf is the tag name we already have.
+        category, _ = self._split_full_path(self._to_str(tag.get("fullPath", "")))
+
+        out["keywordId"] = ref
+        out["mlentory_id"] = KaggleHelper.generate_mlentory_entity_hash_id(
+            "Keyword", ref, platform="Kaggle"
+        )
+        out["name"] = self._to_str(tag.get("name") or ref)
+        out["category"] = category
+        out["description"] = self._to_str(tag.get("description", ""))
+        out["enriched"] = True
+        out["entity_type"] = "Keyword"
+        out["platform"] = "Kaggle"
+        out["extraction_metadata"] = {
+            "extraction_method": "Kaggle_models_endpoint",
+            "confidence": 1.0,
+            "extraction_time": self._extraction_time(),
+        }
+
+        for key, value in list(out.items()):
+            if key == "extraction_metadata":
+                continue  # stays a nested object, as in the other platforms
+            if value is None:
+                out[key] = ""
+            elif isinstance(value, (list, dict)):
+                out[key] = json.dumps(value, ensure_ascii=False)
+
+        return out

--- a/etl_extractors/kaggle/clients/licenses_client.py
+++ b/etl_extractors/kaggle/clients/licenses_client.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from etl_extractors.kaggle.kaggle_helper import KaggleHelper
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleLicenseClient:
+    """
+    Client for interacting with Kaggle Model licenses.
+
+    Kaggle reports a license as a bare name ("MIT", "Apache 2.0") on each
+    model instance - there is no id, url or SPDX identifier in the response -
+    so a license entity is the name plus its minted ``mlentory_id``.
+
+    A model can carry instances under different licenses, so one model may
+    map to several license entities.
+    """
+
+    def __init__(self, records_data=None) -> None:
+        self.records_data = records_data or {}
+
+    def _extraction_time(self) -> str:
+        """
+        Extraction time in the run-folder format (``2026-01-30_05-03-47``).
+
+        ``records_data["timestamp"]`` is an ISO string set at fetch, so it is
+        reformatted here to match the convention used by the other platforms.
+        """
+        raw = str(self.records_data.get("timestamp", "") or "").strip()
+        if not raw:
+            return datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
+        try:
+            return datetime.fromisoformat(
+                raw.replace("Z", "+00:00")
+            ).strftime("%Y-%m-%d_%H-%M-%S")
+        except ValueError:
+            return raw
+
+    def get_licenses_metadata(self, license_ids: List[str]) -> pd.DataFrame:
+        # make unique + deterministic
+        license_ids = sorted({str(x).strip() for x in license_ids if x and str(x).strip()})
+        extraction_time = self._extraction_time()
+
+        all_license_data: List[Dict[str, Any]] = []
+
+        for license_id in license_ids:
+            license_data: Dict[str, Any] = {
+                "licenseId": license_id,
+                "mlentory_id": KaggleHelper.generate_mlentory_entity_hash_id(
+                    "License", license_id, platform="Kaggle"
+                ),
+                "name": license_id,
+                "enriched": True,
+                "entity_type": "License",
+                "platform": "Kaggle",
+                "extraction_metadata": {
+                    "extraction_method": "Kaggle_models_endpoint",
+                    "confidence": 1.0,
+                    "extraction_time": extraction_time,
+                },
+            }
+            all_license_data.append(license_data)
+
+        logger.info("Extracted %d distinct licenses", len(all_license_data))
+        return pd.DataFrame(all_license_data)

--- a/etl_extractors/kaggle/clients/models_client.py
+++ b/etl_extractors/kaggle/clients/models_client.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from etl_extractors.kaggle.kaggle_helper import KaggleHelper
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleModelClient:
+    """Extractor for fetching raw model metadata from the Kaggle platform."""
+
+    def __init__(self, records_data: Dict[str, Any]):
+        # expected: {"data": [...], "timestamp": "..."}
+        self.records_data = records_data or {}
+
+    def get_models_metadata(self) -> pd.DataFrame:
+        """Normalize every fetched model card into a dataframe."""
+        records = self.records_data.get("data", []) or []
+        model_records = [r for r in records if isinstance(r, dict)]
+
+        models_metadata = [self.fetch_model_metadata(model_record) for model_record in model_records]
+        return pd.DataFrame(models_metadata)
+
+    # ---------- helpers for normalization ----------
+
+    @staticmethod
+    def _to_str(value: Any) -> str:
+        """Convert any value to string; missing/None becomes empty string."""
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, dict)):
+            return json.dumps(value, ensure_ascii=False)
+        return str(value)
+
+    @staticmethod
+    def _first_hit(flat: Dict[str, Any], paths: List[str]) -> Any:
+        """Return first non-empty value found in flat for given paths; else None."""
+        for p in paths:
+            if p in flat:
+                v = flat[p]
+                if v is not None and v != "" and v != p:
+                    return v
+        return None
+
+    @classmethod
+    def _join_unique(cls, instances: List[Dict[str, Any]], field: str,
+                     sep: str = ", ") -> str:
+        """Collect distinct non-empty values of `field` across model instances."""
+        values = []
+        for inst in instances:
+            v = cls._to_str(inst.get(field, "")).strip()
+            if v and v not in values:
+                values.append(v)
+        return sep.join(values)
+
+    @staticmethod
+    def _safe_iso_date(ts: Any) -> str:
+        """
+        Convert a Kaggle timestamp to YYYY-MM-DD.
+
+        Kaggle returns ISO 8601 strings on the models endpoint, but Meta
+        Kaggle CSV columns can surface as unix seconds, so handle both.
+        """
+        if isinstance(ts, (int, float)):
+            try:
+                return datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d")
+            except (OverflowError, OSError, ValueError):
+                return ""
+        if isinstance(ts, str) and ts:
+            cleaned = ts.replace("Z", "+00:00")
+            try:
+                return datetime.fromisoformat(cleaned).strftime("%Y-%m-%d")
+            except ValueError:
+                return ts[:10] if len(ts) >= 10 else ""
+        return ""
+
+    def fetch_model_metadata(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch a single model's metadata and normalize all missing values to ''."""
+        flat = self._flatten_dict(record or {})
+
+        # 'ref' is owner/slug and is the stable identifier the crawler keys on.
+        raw_ref = flat.get("ref") or record.get("ref") or ""
+        model_id = self._to_str(raw_ref)
+
+        out: Dict[str, Any] = {}
+
+        # fixed fields
+        out["modelId"] = model_id
+        out["mlentory_id"] = KaggleHelper.generate_mlentory_entity_hash_id(
+            "Model", model_id, platform="Kaggle"
+        )
+        out["extraction_timestamp"] = self._to_str(self.records_data.get("timestamp", ""))
+        out["enriched"] = True
+        out["entity_type"] = "Model"
+        out["platform"] = "Kaggle"
+
+        # url fields
+        out["url"] = f"https://www.kaggle.com/models/{model_id}" if model_id else ""
+        # Kaggle serves the model card as the description field rather than a
+        # separate file, so there is no distinct readme URL to point at.
+        out["readme_file"] = ""
+
+        # paths to extract (do NOT store path-lists in output)
+        #
+        # Mapped against a real models/get response. Note two Kaggle quirks:
+        #   - several fields carry a "Nullable" suffix (voteCountNullable)
+        #   - license/framework/url/version live on INSTANCES, not the model,
+        #     because one model has many framework+variation instances
+        path_map: Dict[str, List[str]] = {
+            "name": ["title", "slug"],
+            "intendedUse": ["description", "subtitle"],
+            "sharedBy": ["author"],
+            "author": ["author"],
+            "maintainer": ["author"],
+            "keywords": ["tags", "keywords"],
+            "citation": ["citation"],
+            "referencePublication": ["publicationUrl", "provenanceSources"],
+            "codeRepository": ["codeRepository", "repositoryUrl"],
+            "downloadCount": ["downloadCountNullable", "downloadCount", "totalDownloads"],
+            "voteCount": ["voteCountNullable", "voteCount", "totalVotes"],
+        }
+
+        # extract fields
+        for key, paths in path_map.items():
+            val = self._first_hit(flat, paths)
+            if val is None or val == "":
+                out[key] = ""
+            else:
+                out[key] = val
+
+        # ---- instance-derived fields ----
+        # A model has many instances (framework x variation). License,
+        # framework, training data and version all live there, so collect
+        # across instances rather than assuming a single value.
+        instances = record.get("instances")
+        instances = instances if isinstance(instances, list) else []
+        dict_instances = [i for i in instances if isinstance(i, dict)]
+
+        out["license"] = self._join_unique(dict_instances, "licenseName")
+        out["modelArchitecture"] = self._join_unique(dict_instances, "framework")
+        out["modelInstanceType"] = self._join_unique(dict_instances, "modelInstanceType")
+        out["num_instances"] = len(dict_instances)
+
+        # trainingData is a list per instance; flatten across all of them
+        training = []
+        for inst in dict_instances:
+            td = inst.get("trainingData")
+            if isinstance(td, list):
+                training.extend(str(t) for t in td if t)
+            elif td:
+                training.append(str(td))
+        seen_td = list(dict.fromkeys(training))
+        out["trainedOn"] = json.dumps(seen_td, ensure_ascii=False) if seen_td else ""
+
+        # version: highest versionNumber across instances
+        versions = [i.get("versionNumber") for i in dict_instances
+                    if isinstance(i.get("versionNumber"), int)]
+        out["version"] = self._to_str(max(versions)) if versions else ""
+
+        # release notes: Kaggle has no versionNotes; the per-instance overview
+        # is the closest equivalent
+        out["releaseNotes"] = self._join_unique(dict_instances, "overview", sep=" | ")
+
+        # instance URLs, useful for provenance and for the enrichment step
+        inst_urls = [self._to_str(i.get("url", "")) for i in dict_instances]
+        inst_urls = [u for u in inst_urls if u]
+        out["instance_urls"] = json.dumps(inst_urls, ensure_ascii=False) if inst_urls else ""
+
+        # storage footprint across all instances
+        total_bytes = sum(i.get("totalUncompressedBytes") or 0 for i in dict_instances
+                          if isinstance(i.get("totalUncompressedBytes"), (int, float)))
+        out["contentSize"] = self._to_str(total_bytes) if total_bytes else ""
+
+        # ---- dates ----
+        # The models/get response carries no timestamps. Meta Kaggle's
+        # Models.csv does, so the crawler can merge them in; when absent
+        # these stay empty rather than being invented.
+        out["dateCreated"] = self._safe_iso_date(
+            self._first_hit(flat, ["publishTime", "creationDate", "CreationDate"])
+        )
+        out["dateModified"] = self._safe_iso_date(
+            self._first_hit(flat, ["lastUpdateTime", "updateTime", "LastUpdateTime"])
+        )
+        out["datePublished"] = out["dateCreated"]
+
+        # conditionsOfAccess: isPrivate is a bool; express it as an access label
+        is_private = self._first_hit(flat, ["isPrivate"])
+        if isinstance(is_private, bool):
+            out["conditionsOfAccess"] = "restricted" if is_private else "public"
+        else:
+            out["conditionsOfAccess"] = ""
+
+        # archivedAt: keep the canonical Kaggle url, as a JSON string
+        archived = [out["url"]] if out.get("url") else []
+        out["archivedAt"] = json.dumps(archived, ensure_ascii=False) if archived else ""
+
+        # sharedBy: if extracted value is a list/dict, string-ify; else string
+        out["sharedBy"] = self._to_str(out.get("sharedBy", ""))
+
+        # contributor fields: convert to list[{"name":..., "url":...}] then JSON string
+        for field in ["author", "maintainer"]:
+            raw = out.get(field, "")
+            parsed: List[Any]
+
+            if isinstance(raw, str):
+                try:
+                    candidate = json.loads(raw)
+                    parsed = candidate if isinstance(candidate, list) else [candidate]
+                except (ValueError, TypeError):
+                    parsed = [raw] if raw else []
+            elif isinstance(raw, dict):
+                parsed = [raw]
+            elif isinstance(raw, list):
+                parsed = raw
+            else:
+                parsed = []
+
+            transformed: List[Dict[str, str]] = []
+            for contributor in parsed:
+                if isinstance(contributor, str):
+                    # Owner slug doubles as the Kaggle profile path.
+                    owner_slug = model_id.split("/", 1)[0] if model_id else ""
+                    url = f"https://www.kaggle.com/{owner_slug}" if owner_slug else ""
+                    transformed.append({"name": contributor, "url": url})
+                    continue
+                if not isinstance(contributor, dict):
+                    continue
+
+                name = self._to_str(contributor.get("name", ""))
+                slug = self._to_str(contributor.get("slug", ""))
+                url = f"https://www.kaggle.com/{slug}" if slug else ""
+                transformed.append({"name": name, "url": url})
+
+            out[field] = json.dumps(transformed, ensure_ascii=False) if transformed else ""
+
+        # finally, enforce: everything missing -> ""
+        for k, v in list(out.items()):
+            if v is None:
+                out[k] = ""
+            elif isinstance(v, (list, dict)):
+                out[k] = json.dumps(v, ensure_ascii=False)
+
+        return out
+
+    def _flatten_dict(self, d: Dict[str, Any], parent_key: str = "", sep: str = ".") -> Dict[str, Any]:
+        """
+        Flatten nested dict keys using dot notation.
+
+        Lists of dicts are indexed (``instances.0.framework``) because Kaggle
+        nests per-framework variations under a list rather than a dict.
+        """
+        items: List[tuple[str, Any]] = []
+        for key, value in (d or {}).items():
+            new_key = f"{parent_key}{sep}{key}" if parent_key else key
+            if isinstance(value, dict):
+                items.extend(self._flatten_dict(value, new_key, sep).items())
+            elif isinstance(value, list) and value and isinstance(value[0], dict):
+                items.append((new_key, value))
+                for idx, element in enumerate(value):
+                    if isinstance(element, dict):
+                        items.extend(
+                            self._flatten_dict(element, f"{new_key}{sep}{idx}", sep).items()
+                        )
+            else:
+                items.append((new_key, value))
+        return dict(items)

--- a/etl_extractors/kaggle/clients/models_client.py
+++ b/etl_extractors/kaggle/clients/models_client.py
@@ -49,6 +49,39 @@ class KaggleModelClient:
                 if v is not None and v != "" and v != p:
                     return v
         return None
+    
+    @classmethod
+    def _distinct(cls, instances: List[Dict[str, Any]], field: str) -> List[str]:
+        """Collect distinct non-empty values of `field` across model instances."""
+        values: List[str] = []
+        for inst in instances:
+            v = cls._to_str(inst.get(field, "")).strip()
+            if v and v not in values:
+                values.append(v)
+        return values
+    
+    @classmethod
+    def _distinct_frameworks(cls, instances: List[Dict[str, Any]]) -> List[str]:
+        """
+        Distinct framework display names, read from each instance URL.
+
+        The URL's third path segment ("TensorFlow2") is the only consistently
+        cased form Kaggle provides; the `framework` field varies by record.
+        """
+        marker = "/models/"
+        names: List[str] = []
+        for inst in instances:
+            url = cls._to_str(inst.get("url", ""))
+            name = ""
+            if url and marker in url:
+                parts = url.split(marker, 1)[1].strip("/").split("/")
+                if len(parts) >= 3:
+                    name = parts[2]
+            if not name:
+                name = cls._to_str(inst.get("framework", "")).strip()
+            if name and name not in names:
+                names.append(name)
+        return names
 
     @classmethod
     def _join_unique(cls, instances: List[Dict[str, Any]], field: str,
@@ -144,7 +177,7 @@ class KaggleModelClient:
         instances = instances if isinstance(instances, list) else []
         dict_instances = [i for i in instances if isinstance(i, dict)]
 
-        out["license"] = self._join_unique(dict_instances, "licenseName")
+        
         out["modelArchitecture"] = self._join_unique(dict_instances, "framework")
         out["modelInstanceType"] = self._join_unique(dict_instances, "modelInstanceType")
         out["num_instances"] = len(dict_instances)
@@ -164,6 +197,32 @@ class KaggleModelClient:
         versions = [i.get("versionNumber") for i in dict_instances
                     if isinstance(i.get("versionNumber"), int)]
         out["version"] = self._to_str(max(versions)) if versions else ""
+        
+        # license lives on instances, and a model can carry several. Keep the
+        # joined string for display, plus a JSON array so downstream consumers
+        # (the license identifier) can recover the individual values - license
+        # names are not safe to split on a comma.
+        out["license"] = self._join_unique(dict_instances, "licenseName")
+        distinct_licenses = self._distinct(dict_instances, "licenseName")
+        out["licenses"] = (
+            json.dumps(distinct_licenses, ensure_ascii=False) if distinct_licenses else ""
+        )
+        
+        # Kaggle reports framework inconsistently across records ("pyTorch",
+        # "keras", "MODEL_FRAMEWORK_TENSOR_FLOW_2"), while the instance URL
+        # always carries a clean display form. Keep the raw joined value for
+        # modelArchitecture, plus a JSON array of the clean names for the
+        # framework identifier - framework names are not safe to split on a
+        # comma.
+        out["modelArchitecture"] = self._join_unique(dict_instances, "framework")
+        distinct_frameworks = self._distinct_frameworks(dict_instances)
+        out["frameworks"] = (
+            json.dumps(distinct_frameworks, ensure_ascii=False)
+            if distinct_frameworks else ""
+        )
+        
+        out["modelInstanceType"] = self._join_unique(dict_instances, "modelInstanceType")
+        out["num_instances"] = len(dict_instances)
 
         # release notes: Kaggle has no versionNotes; the per-instance overview
         # is the closest equivalent

--- a/etl_extractors/kaggle/clients/sharedby_client.py
+++ b/etl_extractors/kaggle/clients/sharedby_client.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List
+import logging
+
+import pandas as pd
+
+from etl_extractors.kaggle.kaggle_helper import KaggleHelper
+
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleSharedByClient:
+    """Build Kaggle sharedBy entity metadata from detected names.
+
+    Kaggle reports the uploader as a bare display name on the models endpoint
+    - there is no id, profile url or user/organization flag - so a sharedBy
+    entity is the name plus its minted ``mlentory_id``.
+    """
+
+    def __init__(self, records_data=None) -> None:
+        self.records_data = records_data or {}
+
+    def _extraction_time(self) -> str:
+        """
+        Extraction time in the run-folder format (``2026-01-30_05-03-47``).
+
+        ``records_data["timestamp"]`` is an ISO string set at fetch, so it is
+        reformatted here to match the convention used by the other platforms.
+        """
+        raw = str(self.records_data.get("timestamp", "") or "").strip()
+        if not raw:
+            return datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S")
+        try:
+            return datetime.fromisoformat(
+                raw.replace("Z", "+00:00")
+            ).strftime("%Y-%m-%d_%H-%M-%S")
+        except ValueError:
+            return raw
+
+    def get_sharedby_metadata(self, names: List[str]) -> pd.DataFrame:
+        unique_names = sorted({str(name).strip() for name in names if str(name).strip()})
+        extraction_time = self._extraction_time()
+
+        records: List[Dict[str, Any]] = []
+        for name in unique_names:
+            records.append(
+                {
+                    "sharedById": name,
+                    "mlentory_id": KaggleHelper.generate_mlentory_entity_hash_id(
+                        "SharedBy", name, platform="Kaggle"
+                    ),
+                    "name": name,
+                    "enriched": True,
+                    # Kaggle does not distinguish users from organizations on
+                    # this endpoint, so Organization matches the AI4Life
+                    # treatment rather than guessing per record.
+                    "entity_type": "Organization",
+                    "platform": "Kaggle",
+                    "extraction_metadata": {
+                        "extraction_method": "kaggle_sharedby_identifier",
+                        "confidence": 1.0,
+                        "source_field": "sharedBy",
+                        "extraction_time": extraction_time,
+                    },
+                }
+            )
+
+        logger.info("Prepared metadata for %d Kaggle sharedBy entities", len(records))
+        return pd.DataFrame(records)

--- a/etl_extractors/kaggle/entity_identifiers/__init__.py
+++ b/etl_extractors/kaggle/entity_identifiers/__init__.py
@@ -1,4 +1,7 @@
 from .base import EntityIdentifier
 from .instance_identifier import InstanceIdentifier
+from .license_identifier import LicenseIdentifier
+from .keyword_identifier import KeywordIdentifier
+from .framework_identifier import FrameworkIdentifier
 
-__all__ = ["EntityIdentifier", "InstanceIdentifier"]
+__all__ = ["EntityIdentifier", "InstanceIdentifier","LicenseIdentifier", "KeywordIdentifier","FrameworkIdentifier"]

--- a/etl_extractors/kaggle/entity_identifiers/__init__.py
+++ b/etl_extractors/kaggle/entity_identifiers/__init__.py
@@ -3,5 +3,7 @@ from .instance_identifier import InstanceIdentifier
 from .license_identifier import LicenseIdentifier
 from .keyword_identifier import KeywordIdentifier
 from .framework_identifier import FrameworkIdentifier
+from .sharedby_identifier import SharedByIdentifier
 
-__all__ = ["EntityIdentifier", "InstanceIdentifier","LicenseIdentifier", "KeywordIdentifier","FrameworkIdentifier"]
+__all__ = ["EntityIdentifier", "InstanceIdentifier","LicenseIdentifier", "KeywordIdentifier",
+           "FrameworkIdentifier","SharedByIdentifier"]

--- a/etl_extractors/kaggle/entity_identifiers/__init__.py
+++ b/etl_extractors/kaggle/entity_identifiers/__init__.py
@@ -1,0 +1,4 @@
+from .base import EntityIdentifier
+from .instance_identifier import InstanceIdentifier
+
+__all__ = ["EntityIdentifier", "InstanceIdentifier"]

--- a/etl_extractors/kaggle/entity_identifiers/base.py
+++ b/etl_extractors/kaggle/entity_identifiers/base.py
@@ -1,0 +1,77 @@
+"""
+Base interface for entity identifiers.
+"""
+
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Set, Dict, Any, List
+import pandas as pd
+
+
+class EntityIdentifier(ABC):
+    """
+    Abstract base class for identifying related entities from model metadata.
+
+    Each subclass extracts a specific type of related entity (e.g., instances,
+    keywords) from raw Kaggle model metadata.
+    """
+
+    @property
+    @abstractmethod
+    def entity_type(self) -> str:
+        """Return the entity type this identifier handles (e.g., 'instances')."""
+        pass
+
+    @abstractmethod
+    def identify(self, models_df: pd.DataFrame) -> Set[str]:
+        """
+        Extract entity IDs/names from the models DataFrame.
+
+        Args:
+            models_df: DataFrame containing raw Kaggle model metadata
+
+        Returns:
+            Set of entity identifiers
+        """
+        pass
+
+    @abstractmethod
+    def identify_per_model(self, models_df: pd.DataFrame) -> Dict[str, List[str]]:
+        """
+        Extract entity IDs/names per model from the models DataFrame.
+
+        Args:
+            models_df: DataFrame containing raw Kaggle model metadata
+
+        Returns:
+            Dict mapping model_id to list of entity identifiers for that model
+        """
+        pass
+
+    @staticmethod
+    def parse_json_field(value: Any) -> List[str]:
+        """
+        Helper to read a list field from a normalized row.
+
+        Normalized Kaggle rows store list values as JSON strings, but the same
+        column may still hold a real list when read straight from a dataframe,
+        so both are accepted.
+
+        Args:
+            value: The raw column value
+
+        Returns:
+            List of string values
+        """
+        if isinstance(value, list):
+            return [str(v) for v in value if v]
+        if isinstance(value, str) and value.strip():
+            import json
+            try:
+                parsed = json.loads(value)
+            except (ValueError, TypeError):
+                return [value]
+            if isinstance(parsed, list):
+                return [str(v) for v in parsed if v]
+            return [str(parsed)] if parsed else []
+        return []

--- a/etl_extractors/kaggle/entity_identifiers/framework_identifier.py
+++ b/etl_extractors/kaggle/entity_identifiers/framework_identifier.py
@@ -1,0 +1,123 @@
+"""
+Identify framework references from Kaggle model metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Set
+
+import pandas as pd
+
+from etl_extractors.kaggle.entity_identifiers.base import EntityIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class FrameworkIdentifier(EntityIdentifier):
+    """
+    Extracts framework names from model metadata.
+
+    On Kaggle the framework belongs to the *instance*, not the model, and one
+    model can carry instances under different frameworks (PyTorch for one
+    variation, Keras for another). ``models_client`` therefore writes a
+    ``frameworks`` JSON array alongside the joined ``modelArchitecture``
+    display string; this reads the array where available.
+
+    The values are frameworks - PyTorch, Keras, TensorFlow2, ScikitLearn -
+    not architectures in the ResNet/BERT sense. They describe the file format
+    an instance ships in.
+
+    Coverage is near-complete: almost every instance declares a framework,
+    unlike tags which are sparse.
+    """
+
+    @property
+    def entity_type(self) -> str:
+        return "frameworks"
+
+    def _get_framework_value(self, row) -> Optional[object]:
+        """
+        Read frameworks off a row, preferring the structured array.
+
+        Falls back to ``modelArchitecture`` for rows written before
+        ``frameworks`` existed.
+        """
+        for column in ("frameworks", "modelArchitecture"):
+            value = row.get(column, None)
+            if value is None or value == "":
+                continue
+            if column == "frameworks":
+                parsed = self._parse_json_field(value)
+                if parsed:
+                    return parsed
+                continue
+            return value
+        return None
+
+    @staticmethod
+    def _parse_json_field(value: Any) -> List[str]:
+        """Read a list field that may arrive as a JSON string or a real list."""
+        if isinstance(value, list):
+            return [str(v).strip() for v in value if str(v).strip()]
+        if isinstance(value, str) and value.strip():
+            try:
+                parsed = json.loads(value)
+            except (ValueError, TypeError):
+                return [value.strip()]
+            if isinstance(parsed, list):
+                return [str(v).strip() for v in parsed if str(v).strip()]
+            return [str(parsed).strip()] if parsed else []
+        return []
+
+    def identify(self, models_df: pd.DataFrame) -> Set[str]:
+        """
+        Unique frameworks across all models.
+        """
+        frameworks: Set[str] = set()
+        if models_df is None or models_df.empty:
+            return frameworks
+
+        for _, row in models_df.iterrows():
+            fw = self._get_framework_value(row)
+            if fw is None or fw == "":
+                continue
+
+            if isinstance(fw, (list, tuple, set)):
+                for x in fw:
+                    if x:
+                        frameworks.add(str(x))
+            else:
+                frameworks.add(str(fw))
+
+        logger.info("Identified %d unique frameworks", len(frameworks))
+        return frameworks
+
+    def identify_per_model(self, models_df: pd.DataFrame) -> Dict[str, List[str]]:
+        """
+        model_id -> [framework(s)]
+        """
+        model_frameworks: Dict[str, List[str]] = {}
+        if models_df is None or models_df.empty:
+            return model_frameworks
+
+        for _, row in models_df.iterrows():
+            model_id = row.get("modelId") or row.get("id")
+            if not model_id:
+                continue
+
+            fw = self._get_framework_value(row)
+            if fw is None or fw == "":
+                model_frameworks[str(model_id)] = []
+                continue
+
+            if isinstance(fw, (list, tuple, set)):
+                vals = [str(x) for x in fw if x]
+            else:
+                vals = [str(fw)]
+
+            model_frameworks[str(model_id)] = vals
+
+        logger.info("Identified frameworks for %d models", len(model_frameworks))
+        return model_frameworks

--- a/etl_extractors/kaggle/entity_identifiers/instance_identifier.py
+++ b/etl_extractors/kaggle/entity_identifiers/instance_identifier.py
@@ -1,0 +1,84 @@
+"""
+Identify model instance references from Kaggle model metadata.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Set
+
+import pandas as pd
+
+from etl_extractors.kaggle.entity_identifiers.base import EntityIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class InstanceIdentifier(EntityIdentifier):
+    """
+    Identify model instances referenced by Kaggle models.
+
+    A Kaggle model is a container; its downloadable artifacts are instances,
+    one per framework and variation. ``Microsoft/phi-3`` has three
+    (pyTorch/mini, pyTorch/moe, keras/vision), each with its own license,
+    version, size and URL.
+
+    Instance ids mirror the Kaggle URL path
+    (``owner/model/framework/variation``) so they round-trip to a real page.
+    """
+
+    @property
+    def entity_type(self) -> str:
+        return "instances"
+
+    def identify(self, models_df: pd.DataFrame) -> Set[str]:
+        """Extract the full set of instance ids across all models."""
+        instances: Set[str] = set()
+        for _, per_model in self.identify_per_model(models_df).items():
+            instances.update(per_model)
+        return instances
+
+    def identify_per_model(self, models_df: pd.DataFrame) -> Dict[str, List[str]]:
+        """Extract instance ids per model."""
+        if models_df is None or models_df.empty:
+            return {}
+
+        if "modelId" not in models_df.columns:
+            logger.warning("Models dataframe has no modelId column")
+            return {}
+
+        model_instances: Dict[str, List[str]] = {}
+        for _, row in models_df.iterrows():
+            model_id = str(row.get("modelId", "")).strip()
+            if not model_id:
+                continue
+
+            instance_ids = self.extract_from_urls(
+                self.parse_json_field(row.get("instance_urls", ""))
+            )
+            if instance_ids:
+                model_instances[model_id] = instance_ids
+
+        logger.info("Identified instances for %d models", len(model_instances))
+        return model_instances
+
+    @staticmethod
+    def extract_from_urls(urls: List[str]) -> List[str]:
+        """
+        Turn Kaggle instance URLs into ``owner/model/framework/variation`` ids.
+
+        Args:
+            urls: Full Kaggle instance URLs
+
+        Returns:
+            Ordered, de-duplicated list of instance ids
+        """
+        marker = "/models/"
+        instance_ids: List[str] = []
+        for url in urls:
+            if not isinstance(url, str) or marker not in url:
+                continue
+            ref = url.split(marker, 1)[1].strip("/")
+            if ref and ref not in instance_ids:
+                instance_ids.append(ref)
+        return instance_ids

--- a/etl_extractors/kaggle/entity_identifiers/keyword_identifier.py
+++ b/etl_extractors/kaggle/entity_identifiers/keyword_identifier.py
@@ -1,0 +1,100 @@
+"""
+Identify keyword (tag) references from Kaggle model metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Set
+
+import pandas as pd
+
+from etl_extractors.kaggle.entity_identifiers.base import EntityIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class KeywordIdentifier(EntityIdentifier):
+    """
+    Identify keywords referenced by Kaggle models.
+
+    Kaggle returns curated tag objects on each model, each carrying a stable
+    ``ref`` ("nlp", "classification"), a human description, and a
+    ``fullPath`` that places it in a taxonomy ("analysis > nlp",
+    "task > classification"). The ``ref`` is what identifies the keyword.
+
+    Coverage is sparse - most models carry no tags at all - so keyword
+    grouping reaches only a subset of the catalog.
+    """
+
+    @property
+    def entity_type(self) -> str:
+        return "keywords"
+
+    def identify(self, models_df: pd.DataFrame) -> Set[str]:
+        """Extract the full set of keyword refs across all models."""
+        keywords: Set[str] = set()
+        for _, per_model in self.identify_per_model(models_df).items():
+            keywords.update(per_model)
+        return keywords
+
+    def identify_per_model(self, models_df: pd.DataFrame) -> Dict[str, List[str]]:
+        """Extract keyword refs per model."""
+        if models_df is None or models_df.empty:
+            return {}
+
+        if "modelId" not in models_df.columns:
+            logger.warning("Models dataframe has no modelId column")
+            return {}
+
+        model_keywords: Dict[str, List[str]] = {}
+        for _, row in models_df.iterrows():
+            model_id = str(row.get("modelId", "")).strip()
+            if not model_id:
+                continue
+
+            refs = self.extract_from_tags(row.get("keywords", ""))
+            if refs:
+                model_keywords[model_id] = refs
+
+        logger.info("Identified keywords for %d models", len(model_keywords))
+        return model_keywords
+
+    @staticmethod
+    def extract_from_tags(tags: Any) -> List[str]:
+        """
+        Pull keyword refs out of Kaggle's tag objects.
+
+        Normalized rows store the tag list as a JSON string, so accept both
+        that and a real list. Falls back to ``name`` when ``ref`` is absent,
+        and tolerates plain strings in case the shape ever changes.
+
+        Args:
+            tags: Tag list, or its JSON-string form
+
+        Returns:
+            Ordered, de-duplicated list of keyword refs
+        """
+        if isinstance(tags, str):
+            if not tags.strip():
+                return []
+            try:
+                tags = json.loads(tags)
+            except (ValueError, TypeError):
+                return [tags.strip()]
+
+        if not isinstance(tags, list):
+            return []
+
+        refs: List[str] = []
+        for tag in tags:
+            if isinstance(tag, dict):
+                ref = str(tag.get("ref") or tag.get("name") or "").strip()
+            elif isinstance(tag, str):
+                ref = tag.strip()
+            else:
+                continue
+            if ref and ref not in refs:
+                refs.append(ref)
+        return refs

--- a/etl_extractors/kaggle/entity_identifiers/license_identifier.py
+++ b/etl_extractors/kaggle/entity_identifiers/license_identifier.py
@@ -1,0 +1,120 @@
+"""
+Identify license references from Kaggle model metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Set
+
+import pandas as pd
+
+from etl_extractors.kaggle.entity_identifiers.base import EntityIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class LicenseIdentifier(EntityIdentifier):
+    """
+    Extracts license ids/names from model metadata.
+
+    On Kaggle the license belongs to the *instance*, not the model, and one
+    model can carry instances under different licenses (e.g. MIT for a PyTorch
+    variation and Apache 2.0 for a Keras one). ``models_client`` therefore
+    writes a ``licenses`` JSON array alongside the joined ``license`` display
+    string; this reads the array where available.
+
+    Splitting the display string on a comma is deliberately avoided - license
+    names legitimately contain punctuation, e.g.
+    "Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)".
+    """
+
+    @property
+    def entity_type(self) -> str:
+        return "licenses"
+
+    def _get_license_value(self, row) -> Optional[object]:
+        """
+        Read licenses off a row, preferring the structured array.
+
+        Falls back to the single ``license`` field (and the British spelling)
+        for rows written before ``licenses`` existed.
+        """
+        for column in ("licenses", "license", "licence"):
+            value = row.get(column, None)
+            if value is None or value == "":
+                continue
+            if column == "licenses":
+                parsed = self._parse_json_field(value)
+                if parsed:
+                    return parsed
+                continue
+            return value
+        return None
+
+    @staticmethod
+    def _parse_json_field(value: Any) -> List[str]:
+        """Read a list field that may arrive as a JSON string or a real list."""
+        if isinstance(value, list):
+            return [str(v).strip() for v in value if str(v).strip()]
+        if isinstance(value, str) and value.strip():
+            try:
+                parsed = json.loads(value)
+            except (ValueError, TypeError):
+                return [value.strip()]
+            if isinstance(parsed, list):
+                return [str(v).strip() for v in parsed if str(v).strip()]
+            return [str(parsed).strip()] if parsed else []
+        return []
+
+    def identify(self, models_df: pd.DataFrame) -> Set[str]:
+        """
+        Unique licenses across all models.
+        """
+        licenses: Set[str] = set()
+        if models_df is None or models_df.empty:
+            return licenses
+
+        for _, row in models_df.iterrows():
+            lic = self._get_license_value(row)
+            if lic is None or lic == "":
+                continue
+
+            if isinstance(lic, (list, tuple, set)):
+                for x in lic:
+                    if x:
+                        licenses.add(str(x))
+            else:
+                licenses.add(str(lic))
+
+        logger.info("Identified %d unique licenses", len(licenses))
+        return licenses
+
+    def identify_per_model(self, models_df: pd.DataFrame) -> Dict[str, List[str]]:
+        """
+        model_id -> [license(s)]
+        """
+        model_licenses: Dict[str, List[str]] = {}
+        if models_df is None or models_df.empty:
+            return model_licenses
+
+        for _, row in models_df.iterrows():
+            model_id = row.get("modelId") or row.get("id")
+            if not model_id:
+                continue
+
+            lic = self._get_license_value(row)
+            if lic is None or lic == "":
+                model_licenses[str(model_id)] = []
+                continue
+
+            if isinstance(lic, (list, tuple, set)):
+                vals = [str(x) for x in lic if x]
+            else:
+                vals = [str(lic)]
+
+            model_licenses[str(model_id)] = vals
+
+        logger.info("Identified licenses for %d models", len(model_licenses))
+        return model_licenses

--- a/etl_extractors/kaggle/entity_identifiers/sharedby_identifier.py
+++ b/etl_extractors/kaggle/entity_identifiers/sharedby_identifier.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Dict, List, Set
+import logging
+
+import pandas as pd
+
+from .base import EntityIdentifier
+
+
+logger = logging.getLogger(__name__)
+
+
+class SharedByIdentifier(EntityIdentifier):
+    """Identify sharedBy entities from Kaggle model metadata.
+
+    On Kaggle this is the account that uploaded the model - a user or an
+    organization - taken from the ``author`` field on the models endpoint.
+    Instances inherit it from their parent, so both come through the same
+    ``sharedBy`` column.
+    """
+
+    @property
+    def entity_type(self) -> str:
+        return "sharedby"
+
+    def identify(self, models_df: pd.DataFrame) -> Set[str]:
+        values: Set[str] = set()
+        if models_df is None or models_df.empty:
+            return values
+
+        for _, row in models_df.iterrows():
+            sharedby = self._extract_sharedby(row)
+            if sharedby:
+                values.add(sharedby)
+
+        logger.info("Identified %d unique Kaggle sharedBy entities", len(values))
+        return values
+
+    def identify_per_model(self, models_df: pd.DataFrame) -> Dict[str, List[str]]:
+        model_values: Dict[str, List[str]] = {}
+        if models_df is None or models_df.empty:
+            return model_values
+
+        for _, row in models_df.iterrows():
+            model_id = row.get("modelId") or row.get("id") or row.get("model_id") or row.get("name")
+            if not model_id:
+                continue
+            sharedby = self._extract_sharedby(row)
+            model_values[str(model_id)] = [sharedby] if sharedby else []
+
+        logger.info("Identified Kaggle sharedBy values for %d models", len(model_values))
+        return model_values
+
+    @staticmethod
+    def _extract_sharedby(row: pd.Series) -> str:
+        """
+        Read the owner name off a row.
+
+        Only ``sharedBy`` and the plain form of ``author`` are used.
+        ``parent_name`` is deliberately not a fallback: on an instance row it
+        holds the parent model's *title*, not its owner, so it would mint
+        entities like "Phi-3" as if they were people.
+        """
+        for column in ("sharedBy", "author"):
+            value = row.get(column)
+            if value is None:
+                continue
+            text = str(value).strip()
+            # pandas turns missing cells into the float nan, whose str() is
+            # "nan" - a string that would otherwise become a real entity.
+            if not text or text.lower() in {"none", "nan"}:
+                continue
+            # models_client writes author as a JSON array of {name, url}; the
+            # plain owner string lives in sharedBy, so skip the encoded form.
+            if text.startswith("[") or text.startswith("{"):
+                continue
+            return text
+        return ""

--- a/etl_extractors/kaggle/kaggle_crawler.py
+++ b/etl_extractors/kaggle/kaggle_crawler.py
@@ -1,0 +1,660 @@
+"""
+Kaggle model-card crawler.
+
+Fetches model cards from the Kaggle API for every model listed in the Meta
+Kaggle dataset. Parallel, resumable, and incremental.
+
+Rate limiting notes (measured against the live API, not guessed):
+  Kaggle enforces a rolling hourly quota on models/get of roughly 7-9k
+  records. Throttling occurs even at 0.5 req/s, which rules out a per-second
+  speed cap. Multiple configurations converged on the same hourly total, so
+  raising RPS does NOT increase throughput - it only produces more 429s and
+  wastes quota on rejected requests. These values are class constants rather
+  than config for that reason.
+
+Baseline crawl of ~42k models takes ~6h. Incremental runs fetch only new or
+changed models (~1k) and take ~10 min.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
+
+import requests
+from requests.adapters import HTTPAdapter
+
+logger = logging.getLogger(__name__)
+
+KAGGLE_BASE = "https://www.kaggle.com/api/v1"
+
+TERMINAL_STATUS = {400, 401, 403, 404, 410}
+RETRY_STATUS = {500, 502, 503, 504}
+
+
+# ==========================================================================
+# Rate limiting
+# ==========================================================================
+
+class _RateLimiter:
+    """
+    Adaptive global rate limiter (AIMD - additive increase, multiplicative
+    decrease). Shared across all worker threads.
+    """
+
+    def __init__(self, rps: float, min_rps: float, max_rps: float,
+                 increase_after: int = 50, increase_step: float = 0.5):
+        self.rps = float(rps)
+        self.min_rps = float(min_rps)
+        self.max_rps = float(max_rps)
+        self.increase_after = increase_after
+        self.increase_step = increase_step
+        self._lock = threading.Lock()
+        self._next_at = time.monotonic()
+        self._streak = 0
+
+    def acquire(self) -> None:
+        with self._lock:
+            interval = 1.0 / self.rps
+            now = time.monotonic()
+            self._next_at = max(self._next_at, now)
+            wait = self._next_at - now
+            self._next_at += interval
+        if wait > 0:
+            time.sleep(wait)
+
+    def penalize(self) -> None:
+        with self._lock:
+            self._streak = 0
+            new = max(self.min_rps, self.rps / 2.0)
+            changed = new != self.rps
+            self.rps = new
+        if changed:
+            logger.debug("Rate limit lowered to %.2f rps", new)
+
+    def reward(self) -> None:
+        with self._lock:
+            self._streak += 1
+            if self._streak < self.increase_after or self.rps >= self.max_rps:
+                return
+            self._streak = 0
+            self.rps = min(self.max_rps, self.rps + self.increase_step)
+            new = self.rps
+        logger.debug("Rate limit raised to %.2f rps", new)
+
+
+class _Brake:
+    """On a 429, all workers pause together rather than piling on."""
+
+    def __init__(self, limiter: _RateLimiter, stop: threading.Event):
+        self._open = threading.Event()
+        self._open.set()
+        self._lock = threading.Lock()
+        self._limiter = limiter
+        self._stop = stop
+        self.engagements = 0
+
+    def wait(self) -> None:
+        self._open.wait()
+
+    def engage(self, seconds: float) -> None:
+        with self._lock:
+            if not self._open.is_set():
+                return  # another thread is already braking
+            self._open.clear()
+            self.engagements += 1
+        self._limiter.penalize()
+        logger.info("Rate limited; pausing all workers %.0fs (pause #%d)",
+                    seconds, self.engagements)
+        end = time.monotonic() + seconds
+        while time.monotonic() < end and not self._stop.is_set():
+            time.sleep(min(0.5, end - time.monotonic()))
+        self._open.set()
+
+
+# ==========================================================================
+# Extractor
+# ==========================================================================
+
+class KaggleCrawler:
+    """
+    Extract Kaggle model cards into an append-only NDJSON log plus a final
+    JSON array.
+
+    Output layout under ``output_dir``::
+
+        meta_kaggle/                    Models/Organizations/Users CSVs
+        kaggle_all_model_refs.json      owner/slug list
+        kaggle_models_raw.ndjson        append-only, drives resume + dedup
+        kaggle_models_raw.json          final array
+        kaggle_model_get_failures.json
+        kaggle_model_get_progress.json
+        kaggle_fetch_state.json         fingerprints for incremental runs
+    """
+
+    # Measured ceiling - see module docstring. Not exposed via config.
+    RPS = 2.0
+    MIN_RPS = 0.5
+    MAX_RPS = 3.0
+
+    def __init__(
+        self,
+        output_dir: str,
+        threads: int = 8,
+        max_retries: int = 6,
+        request_timeout_seconds: int = 30,
+        checkpoint_every: int = 200,
+        meta_dataset: str = "kaggle/meta-kaggle",
+        api_token: Optional[str] = None,
+    ):
+        self.output_dir = Path(output_dir)
+        self.meta_dir = self.output_dir / "meta_kaggle"
+        self.refs_file = self.output_dir / "kaggle_all_model_refs.json"
+        self.ndjson_file = self.output_dir / "kaggle_models_raw.ndjson"
+        self.output_file = self.output_dir / "kaggle_models_raw.json"
+        self.failures_file = self.output_dir / "kaggle_model_get_failures.json"
+        self.progress_file = self.output_dir / "kaggle_model_get_progress.json"
+        self.state_file = self.output_dir / "kaggle_fetch_state.json"
+
+        self.meta_dir.mkdir(parents=True, exist_ok=True)
+
+        self.threads = threads
+        self.max_retries = max_retries
+        self.timeout = request_timeout_seconds
+        self.checkpoint_every = checkpoint_every
+        self.meta_dataset = meta_dataset
+
+        # `import kaggle` authenticates on import and pops KAGGLE_API_TOKEN
+        # out of os.environ (Kaggle/kaggle-cli#882), so capture it up front.
+        self._token = (api_token or os.getenv("KAGGLE_API_TOKEN") or "").strip()
+        if not self._token:
+            token_file = Path.home() / ".kaggle" / "access_token"
+            if token_file.exists():
+                self._token = token_file.read_text(encoding="utf-8").strip()
+
+        self._auth_mode: Optional[str] = None
+        self._local = threading.local()
+        self._stop = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+
+    def _auth_candidates(self) -> List[Tuple[str, Dict[str, Any], str]]:
+        out = []
+        if self._token:
+            out.append(("bearer",
+                        {"headers": {"Authorization": f"Bearer {self._token}"}},
+                        "KAGGLE_API_TOKEN"))
+        user, key = os.getenv("KAGGLE_USERNAME"), os.getenv("KAGGLE_KEY")
+        if user and key:
+            out.append(("basic",
+                        {"auth": (user.strip(), key.strip())},
+                        "KAGGLE_USERNAME/KEY"))
+        return out
+
+    def check_credentials(self) -> bool:
+        """Probe the API and remember which auth scheme works."""
+        candidates = self._auth_candidates()
+        if not candidates:
+            raise RuntimeError(
+                "No Kaggle credentials found. Set KAGGLE_API_TOKEN in .env "
+                "(kaggle.com/settings -> API -> Generate New Token)."
+            )
+
+        errors = []
+        for mode, kwargs, label in candidates:
+            try:
+                r = requests.get(f"{KAGGLE_BASE}/models/list",
+                                 params={"pageSize": 1},
+                                 timeout=self.timeout, **kwargs)
+            except requests.RequestException as e:
+                errors.append(f"{label}: {type(e).__name__}: {e}")
+                continue
+            if r.ok:
+                self._auth_mode = mode
+                logger.info("Kaggle credentials accepted (%s)", label)
+                return True
+            errors.append(f"{label}: HTTP {r.status_code}")
+
+        raise RuntimeError("Kaggle rejected all credentials: " + "; ".join(errors))
+
+    def _session(self) -> requests.Session:
+        """One pooled Session per worker thread."""
+        s = getattr(self._local, "session", None)
+        if s is None:
+            if self._auth_mode is None:
+                self.check_credentials()
+            s = requests.Session()
+            if self._auth_mode == "bearer":
+                s.headers["Authorization"] = f"Bearer {self._token}"
+            else:
+                s.auth = (os.environ["KAGGLE_USERNAME"].strip(),
+                          os.environ["KAGGLE_KEY"].strip())
+            s.headers["Accept"] = "application/json"
+            s.mount("https://", HTTPAdapter(pool_connections=4, pool_maxsize=4,
+                                            max_retries=0))
+            self._local.session = s
+        return s
+
+    def _kaggle_client(self):
+        """The module-level pre-authenticated client (see #882)."""
+        import kaggle
+        api = getattr(kaggle, "api", None)
+        if api is not None:
+            return api
+        from kaggle.api.kaggle_api_extended import KaggleApi
+        api = KaggleApi()
+        api.authenticate()
+        return api
+
+    # ------------------------------------------------------------------
+    # Meta Kaggle -> refs
+    # ------------------------------------------------------------------
+
+    def ensure_meta_kaggle_csvs(self, force: bool = False) -> None:
+        api = self._kaggle_client()
+        for name in ("Models.csv", "Organizations.csv", "Users.csv"):
+            path = self.meta_dir / name
+            if path.exists() and not force:
+                logger.info("Cached %s (%.1f MB)", name, path.stat().st_size / 1e6)
+                continue
+            logger.info("Downloading %s ...", name)
+            api.dataset_download_file(self.meta_dataset, name,
+                                      path=str(self.meta_dir), force=True, quiet=True)
+            logger.info("Saved %s (%.1f MB)", name, path.stat().st_size / 1e6)
+
+    def _join_model_rows(self) -> Iterator[Tuple[str, Dict[str, str]]]:
+        """Yield (ref, row) for every model that resolves to an owner."""
+        with open(self.meta_dir / "Models.csv", newline="", encoding="utf-8") as f:
+            models = list(csv.DictReader(f))
+        with open(self.meta_dir / "Organizations.csv", newline="", encoding="utf-8") as f:
+            orgs = {r["Id"]: r["Slug"] for r in csv.DictReader(f)}
+
+        needed = {r["OwnerUserId"].strip() for r in models
+                  if (r.get("OwnerUserId") or "").strip()}
+        users = {}
+        with open(self.meta_dir / "Users.csv", newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                if row["Id"] in needed:
+                    users[row["Id"]] = row["UserName"]
+
+        for row in models:
+            slug = (row.get("CurrentSlug") or "").strip()
+            if not slug:
+                continue
+            org_id = (row.get("OwnerOrganizationId") or "").strip()
+            user_id = (row.get("OwnerUserId") or "").strip()
+            owner = orgs.get(org_id) if org_id else users.get(user_id)
+            if owner:
+                yield f"{owner}/{slug}", row
+
+    def build_refs(self) -> List[str]:
+        refs = sorted({ref for ref, _ in self._join_model_rows()})
+        self.refs_file.write_text(json.dumps(refs, indent=2), encoding="utf-8")
+        logger.info("Built %d unique refs -> %s", len(refs), self.refs_file)
+        return refs
+
+    def load_or_build_refs(self, rebuild: bool = False) -> List[str]:
+        if self.refs_file.exists() and not rebuild:
+            refs = json.loads(self.refs_file.read_text(encoding="utf-8"))
+            logger.info("Loaded %d refs from %s", len(refs), self.refs_file)
+            return refs
+        self.ensure_meta_kaggle_csvs()
+        return self.build_refs()
+
+    # ------------------------------------------------------------------
+    # Change detection
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _change_columns(fieldnames: List[str]) -> List[str]:
+        """
+        Pick columns that signal a model changed. Meta Kaggle column names
+        aren't guaranteed stable across releases, so detect rather than
+        hardcode: anything date-ish or version-ish, plus the slug.
+        """
+        if not fieldnames:
+            return []
+        wanted = [n for n in fieldnames
+                  if any(t in n.lower()
+                         for t in ("date", "version", "updated", "lastactivity"))]
+        if "CurrentSlug" in fieldnames:
+            wanted.append("CurrentSlug")
+        return sorted(set(wanted))
+
+    def build_ref_fingerprints(self) -> Tuple[Dict[str, str], List[str]]:
+        fps: Dict[str, str] = {}
+        cols: Optional[List[str]] = None
+        for ref, row in self._join_model_rows():
+            if cols is None:
+                cols = self._change_columns(list(row.keys()))
+                logger.info("Change-signal columns: %s", cols or "(none)")
+            if not cols:
+                fps[ref] = ""
+                continue
+            blob = "|".join(str(row.get(c, "")) for c in cols)
+            fps[ref] = hashlib.md5(blob.encode("utf-8")).hexdigest()[:12]
+        return fps, (cols or [])
+
+    def plan_incremental(self) -> Dict[str, Any]:
+        """Return {new, changed, unchanged, gone, fingerprints, columns}."""
+        fps, cols = self.build_ref_fingerprints()
+
+        old: Dict[str, str] = {}
+        if self.state_file.exists():
+            old = json.loads(self.state_file.read_text(encoding="utf-8")).get(
+                "fingerprints", {})
+
+        have = self._load_done_refs()
+        new, changed, unchanged = [], [], []
+        for ref, fp in fps.items():
+            if ref not in have:
+                new.append(ref)
+            elif cols and old.get(ref) != fp:
+                changed.append(ref)
+            else:
+                unchanged.append(ref)
+
+        plan = {"new": sorted(new), "changed": sorted(changed),
+                "unchanged": sorted(unchanged), "gone": sorted(have - set(fps)),
+                "fingerprints": fps, "columns": cols}
+        logger.info("Plan: %d new, %d changed, %d unchanged",
+                    len(new), len(changed), len(unchanged))
+        return plan
+
+    # ------------------------------------------------------------------
+    # Fetch
+    # ------------------------------------------------------------------
+
+    def _fetch_one(self, ref, limiter, brake, out_q, fail_q, stats) -> None:
+        if self._stop.is_set():
+            return
+        owner, _, slug = ref.partition("/")
+        url = f"{KAGGLE_BASE}/models/{owner}/{slug}/get"
+
+        for attempt in range(1, self.max_retries + 1):
+            if self._stop.is_set():
+                return
+            brake.wait()
+            limiter.acquire()
+
+            try:
+                r = self._session().get(url, timeout=self.timeout)
+            except requests.RequestException as e:
+                if attempt == self.max_retries:
+                    fail_q.put({"ref": ref, "error": f"{type(e).__name__}: {e}"})
+                    stats["failed"] += 1
+                    return
+                time.sleep(min(2 ** attempt, 30))
+                continue
+
+            if r.status_code == 429:
+                stats["rate_limited"] += 1
+                try:
+                    wait = max(float(r.headers.get("Retry-After", 60)), 1.0)
+                except (TypeError, ValueError):
+                    wait = 60.0
+                brake.engage(wait)
+                continue
+
+            if r.status_code in RETRY_STATUS:
+                if attempt == self.max_retries:
+                    fail_q.put({"ref": ref, "error": f"HTTP {r.status_code}"})
+                    stats["failed"] += 1
+                    return
+                time.sleep(min(2 ** attempt, 30))
+                continue
+
+            if r.status_code in TERMINAL_STATUS:
+                fail_q.put({"ref": ref, "error": f"HTTP {r.status_code}"})
+                stats["failed"] += 1
+                return
+
+            if r.ok:
+                try:
+                    data = r.json()
+                except ValueError:
+                    fail_q.put({"ref": ref, "error": "invalid JSON"})
+                    stats["failed"] += 1
+                    return
+                data.setdefault("ref", ref)
+                out_q.put(data)
+                stats["ok"] += 1
+                limiter.reward()
+                return
+
+            fail_q.put({"ref": ref, "error": f"HTTP {r.status_code}"})
+            stats["failed"] += 1
+            return
+
+        fail_q.put({"ref": ref, "error": "max_retries exceeded"})
+        stats["failed"] += 1
+
+    def _writer(self, q: "queue.Queue") -> None:
+        """Single thread owns the file handle. Sentinel None ends it."""
+        with open(self.ndjson_file, "a", encoding="utf-8") as f:
+            n = 0
+            while True:
+                row = q.get()
+                if row is None:
+                    break
+                f.write(json.dumps(row, ensure_ascii=False, default=str) + "\n")
+                n += 1
+                if n % self.checkpoint_every == 0:
+                    f.flush()
+                    os.fsync(f.fileno())
+            f.flush()
+            os.fsync(f.fileno())
+
+    def _load_done_refs(self) -> Set[str]:
+        done: Set[str] = set()
+        if not self.ndjson_file.exists():
+            return done
+        with open(self.ndjson_file, encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    ref = json.loads(line).get("ref")
+                except ValueError:
+                    continue  # tolerate a torn last line from a hard kill
+                if ref:
+                    done.add(ref)
+        return done
+
+    def _rewrite_json_array(self) -> int:
+        """
+        Stream NDJSON -> JSON array, keeping only the LAST record per ref.
+        Incremental runs append fresh copies of changed models, so older
+        copies must be dropped. Two passes keep memory flat.
+        """
+        if not self.ndjson_file.exists():
+            return 0
+
+        keep: Dict[str, int] = {}
+        malformed = 0
+        with open(self.ndjson_file, encoding="utf-8") as src:
+            for i, line in enumerate(src):
+                if not line.strip():
+                    continue
+                try:
+                    ref = json.loads(line).get("ref")
+                except ValueError:
+                    malformed += 1
+                    continue
+                keep[ref or f"__noref_{i}"] = i
+        winners = set(keep.values())
+
+        tmp = str(self.output_file) + ".tmp"
+        n = 0
+        with open(self.ndjson_file, encoding="utf-8") as src, \
+                open(tmp, "w", encoding="utf-8") as dst:
+            dst.write("[")
+            first = True
+            for i, line in enumerate(src):
+                if i not in winners:
+                    continue
+                if not first:
+                    dst.write(",")
+                dst.write(line.rstrip("\n"))
+                first = False
+                n += 1
+            dst.write("]")
+        os.replace(tmp, self.output_file)
+
+        if malformed:
+            logger.warning("Skipped %d malformed NDJSON line(s)", malformed)
+        return n
+
+    def fetch_model_cards(
+        self,
+        refs: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        skip_done: bool = True,
+        retry_failed: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Fetch model cards for ``refs``. Resumable and interrupt-safe.
+
+        Returns a summary dict suitable for Dagster metadata.
+        """
+        self._stop.clear()
+        if self._auth_mode is None:
+            self.check_credentials()
+
+        if refs is None:
+            refs = self.load_or_build_refs()
+        if limit:
+            refs = refs[:limit]
+
+        done = self._load_done_refs() if skip_done else set()
+
+        failed: List[Dict[str, str]] = []
+        if self.failures_file.exists():
+            failed = json.loads(self.failures_file.read_text(encoding="utf-8"))
+        failed_refs = set() if retry_failed else {r["ref"] for r in failed}
+        if retry_failed:
+            failed = []
+
+        remaining = [r for r in refs if r not in done and r not in failed_refs]
+        logger.info("Fetching %d refs (%d already held, %d previously failed)",
+                    len(remaining), len(done), len(failed_refs))
+
+        if not remaining:
+            total = self._rewrite_json_array()
+            return {"fetched": 0, "total_records": total, "failed": len(failed),
+                    "elapsed_s": 0.0, "rate_limit_pauses": 0}
+
+        limiter = _RateLimiter(self.RPS, self.MIN_RPS, self.MAX_RPS)
+        brake = _Brake(limiter, self._stop)
+        stats = {"ok": 0, "failed": 0, "rate_limited": 0}
+        out_q: "queue.Queue" = queue.Queue(maxsize=2000)
+        fail_q: "queue.Queue" = queue.Queue()
+
+        writer = threading.Thread(target=self._writer, args=(out_q,), daemon=True)
+        writer.start()
+
+        t0 = time.monotonic()
+        pool = ThreadPoolExecutor(max_workers=self.threads)
+        futures = [pool.submit(self._fetch_one, ref, limiter, brake,
+                               out_q, fail_q, stats) for ref in remaining]
+        try:
+            for i, _ in enumerate(as_completed(futures), 1):
+                if i % 500 == 0 or i == len(futures):
+                    elapsed = time.monotonic() - t0
+                    rate = i / elapsed if elapsed else 0
+                    logger.info("%d/%d ok=%d fail=%d 429s=%d %.1f/s eta %.0fm",
+                                i, len(futures), stats["ok"], stats["failed"],
+                                stats["rate_limited"], rate,
+                                (len(futures) - i) / rate / 60 if rate else 0)
+        except KeyboardInterrupt:
+            logger.warning("Interrupted - flushing collected records")
+            self._stop.set()
+            for fut in futures:
+                fut.cancel()
+        finally:
+            pool.shutdown(wait=True)
+            out_q.put(None)
+            writer.join()
+
+        while not fail_q.empty():
+            failed.append(fail_q.get())
+
+        total = self._rewrite_json_array()
+        elapsed = time.monotonic() - t0
+
+        self._save_json(self.failures_file, failed)
+        summary = {
+            "fetched": stats["ok"],
+            "total_records": total,
+            "failed": len(failed),
+            "rate_limited": stats["rate_limited"],
+            "rate_limit_pauses": brake.engagements,
+            "elapsed_s": round(elapsed, 1),
+            "records_per_second": round(stats["ok"] / elapsed, 2) if elapsed else 0,
+        }
+        self._save_json(self.progress_file, summary)
+        logger.info("Done: %d records in %.1f min (%.2f/s), %d failed",
+                    total, elapsed / 60, summary["records_per_second"], len(failed))
+        return summary
+
+    def fetch_incremental(self, refresh_csvs: bool = True,
+                          force_all: bool = False,
+                          limit: Optional[int] = None) -> Dict[str, Any]:
+        """Fetch only models that are new or changed since the last run."""
+        if refresh_csvs:
+            self.ensure_meta_kaggle_csvs(force=True)
+
+        plan = self.plan_incremental()
+        todo = sorted(plan["fingerprints"]) if force_all else plan["new"] + plan["changed"]
+
+        if not todo:
+            total = self._rewrite_json_array()
+            logger.info("Nothing to fetch; %d records current", total)
+            return {"fetched": 0, "total_records": total, "new": 0, "changed": 0}
+
+        # skip_done=False because changed refs are already in the NDJSON and
+        # must be refetched; _rewrite_json_array dedupes by ref afterwards.
+        summary = self.fetch_model_cards(refs=todo, limit=limit, skip_done=False)
+
+        # Record fingerprints only for refs actually held, so an interrupted
+        # run never marks unfetched models as current.
+        have = self._load_done_refs()
+        self._save_json(self.state_file, {
+            "updated_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "columns": plan["columns"],
+            "fingerprints": {r: fp for r, fp in plan["fingerprints"].items()
+                             if r in have},
+        })
+        summary.update({"new": len(plan["new"]), "changed": len(plan["changed"])})
+        return summary
+
+    def load_records(self) -> List[Dict[str, Any]]:
+        """
+        Return every fetched model card, newest copy per ref.
+
+        Reads the deduplicated JSON array written by _rewrite_json_array so
+        callers get the same records the file on disk holds.
+        """
+        if not self.output_file.exists():
+            self._rewrite_json_array()
+        if not self.output_file.exists():
+            return []
+        return json.loads(self.output_file.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _save_json(path, data) -> None:
+        tmp = str(path) + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False, default=str)
+        os.replace(tmp, path)

--- a/etl_extractors/kaggle/kaggle_crawler.py
+++ b/etl_extractors/kaggle/kaggle_crawler.py
@@ -142,9 +142,9 @@ class KaggleCrawler:
     """
 
     # Measured ceiling - see module docstring. Not exposed via config.
-    RPS = 2.0
+    RPS = 1.0
     MIN_RPS = 0.5
-    MAX_RPS = 3.0
+    MAX_RPS = 1.0
 
     def __init__(
         self,

--- a/etl_extractors/kaggle/kaggle_enrichment.py
+++ b/etl_extractors/kaggle/kaggle_enrichment.py
@@ -12,9 +12,10 @@ from typing import Dict
 
 from etl_extractors.kaggle.entity_identifiers.base import EntityIdentifier
 from etl_extractors.kaggle.entity_identifiers.instance_identifier import InstanceIdentifier
-from etl_extractors.kaggle.entity_identifiers.license_identifier import LicenseIdentifier
 from etl_extractors.kaggle.entity_identifiers.keyword_identifier import KeywordIdentifier
+from etl_extractors.kaggle.entity_identifiers.license_identifier import LicenseIdentifier
 from etl_extractors.kaggle.entity_identifiers.framework_identifier import FrameworkIdentifier
+from etl_extractors.kaggle.entity_identifiers.sharedby_identifier import SharedByIdentifier
 
 logger = logging.getLogger(__name__)
 
@@ -25,8 +26,8 @@ class KaggleEnrichment:
     def __init__(self) -> None:
         self.identifiers: Dict[str, EntityIdentifier] = {
             "instances": InstanceIdentifier(),
-            "licenses": LicenseIdentifier(),
             "keywords": KeywordIdentifier(),
+            "licenses": LicenseIdentifier(),
             "frameworks": FrameworkIdentifier(),
-            
+            "sharedby": SharedByIdentifier()
         }

--- a/etl_extractors/kaggle/kaggle_enrichment.py
+++ b/etl_extractors/kaggle/kaggle_enrichment.py
@@ -1,0 +1,25 @@
+"""
+Enrichment orchestration for Kaggle extraction.
+
+Holds the registry of entity identifiers used by the enrichment assets to
+find related entities inside already-fetched model metadata.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from etl_extractors.kaggle.entity_identifiers.base import EntityIdentifier
+from etl_extractors.kaggle.entity_identifiers.instance_identifier import InstanceIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleEnrichment:
+    """Registry of entity identifiers for Kaggle model metadata."""
+
+    def __init__(self) -> None:
+        self.identifiers: Dict[str, EntityIdentifier] = {
+            "instances": InstanceIdentifier(),
+        }

--- a/etl_extractors/kaggle/kaggle_enrichment.py
+++ b/etl_extractors/kaggle/kaggle_enrichment.py
@@ -12,6 +12,9 @@ from typing import Dict
 
 from etl_extractors.kaggle.entity_identifiers.base import EntityIdentifier
 from etl_extractors.kaggle.entity_identifiers.instance_identifier import InstanceIdentifier
+from etl_extractors.kaggle.entity_identifiers.license_identifier import LicenseIdentifier
+from etl_extractors.kaggle.entity_identifiers.keyword_identifier import KeywordIdentifier
+from etl_extractors.kaggle.entity_identifiers.framework_identifier import FrameworkIdentifier
 
 logger = logging.getLogger(__name__)
 
@@ -22,4 +25,8 @@ class KaggleEnrichment:
     def __init__(self) -> None:
         self.identifiers: Dict[str, EntityIdentifier] = {
             "instances": InstanceIdentifier(),
+            "licenses": LicenseIdentifier(),
+            "keywords": KeywordIdentifier(),
+            "frameworks": FrameworkIdentifier(),
+            
         }

--- a/etl_extractors/kaggle/kaggle_extractor.py
+++ b/etl_extractors/kaggle/kaggle_extractor.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+from etl_extractors.kaggle.clients.models_client import KaggleModelClient
+from etl_extractors.kaggle.clients.instances_client import KaggleInstancesClient
+from etl_extractors.kaggle.kaggle_crawler import KaggleCrawler
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleExtractor:
+    """Extractor for fetching raw model metadata from the Kaggle platform.
+
+    Unlike single-request platforms, Kaggle needs one API call per model
+    (~42k of them), so ``fetch_records`` delegates to :class:`KaggleCrawler`,
+    which handles parallelism, rate limiting, resume-on-crash, and
+    incremental refresh. Everything downstream of that follows the usual
+    client-per-entity pattern.
+    """
+
+    def __init__(
+        self,
+        records_data: Optional[Dict[str, Any]] = None,
+        models_client: Optional[KaggleModelClient] = None,
+        instances_client: Optional[KaggleInstancesClient] = None,
+        crawler: Optional[KaggleCrawler] = None,
+    ) -> None:
+        self.models_client = models_client or KaggleModelClient(records_data)
+        self.crawler = crawler
+        self.instances_client = instances_client or KaggleInstancesClient(records_data)
+
+    def fetch_records(
+        self,
+        output_dir: str,
+        num_models: Optional[int] = None,
+        incremental: bool = True,
+        force_full_refresh: bool = False,
+        refresh_metadata: bool = True,
+        threads: int = 8,
+        max_retries: int = 6,
+        request_timeout_seconds: int = 30,
+        checkpoint_every: int = 200,
+        meta_dataset: str = "kaggle/meta-kaggle",
+    ) -> Tuple[Dict[str, Any], str]:
+        """Fetch model cards from the Kaggle API and set extraction timestamp.
+
+        Returns ``({"data": [...], "summary": {...}}, timestamp)``. The crawl
+        is resumable: an interrupted run re-entered with the same
+        ``output_dir`` continues from its last checkpoint.
+        """
+        try:
+            crawler = self.crawler or KaggleCrawler(
+                output_dir=output_dir,
+                threads=threads,
+                max_retries=max_retries,
+                request_timeout_seconds=request_timeout_seconds,
+                checkpoint_every=checkpoint_every,
+                meta_dataset=meta_dataset,
+            )
+            self.crawler = crawler
+            crawler.check_credentials()
+
+            extraction_timestamp = datetime.utcnow().isoformat()
+
+            if incremental and not force_full_refresh:
+                summary = crawler.fetch_incremental(
+                    refresh_csvs=refresh_metadata, limit=num_models
+                )
+            else:
+                refs = crawler.load_or_build_refs(rebuild=refresh_metadata)
+                summary = crawler.fetch_model_cards(refs=refs, limit=num_models)
+
+            records = crawler.load_records()
+            payload = {"data": records, "summary": summary}
+            return payload, extraction_timestamp
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"Failed to fetch Kaggle records: {exc}") from exc
+
+    def extract_models(self) -> pd.DataFrame:
+        df = self.models_client.get_models_metadata()
+        return df
+    
+    def extract_specific_instances(self, instance_ids) -> pd.DataFrame:
+        df = self.instances_client.get_instances_metadata(instance_ids)
+        return df

--- a/etl_extractors/kaggle/kaggle_extractor.py
+++ b/etl_extractors/kaggle/kaggle_extractor.py
@@ -8,11 +8,12 @@ import pandas as pd
 
 from etl_extractors.kaggle.clients.models_client import KaggleModelClient
 from etl_extractors.kaggle.clients.instances_client import KaggleInstancesClient
-from etl_extractors.kaggle.clients.licenses_client import KaggleLicenseClient
 from etl_extractors.kaggle.clients.keywords_client import KaggleKeywordsClient
+from etl_extractors.kaggle.clients.licenses_client import KaggleLicenseClient
 from etl_extractors.kaggle.clients.frameworks_client import KaggleFrameworkClient
-
+from etl_extractors.kaggle.clients.sharedby_client import KaggleSharedByClient
 from etl_extractors.kaggle.kaggle_crawler import KaggleCrawler
+
 
 logger = logging.getLogger(__name__)
 
@@ -30,19 +31,21 @@ class KaggleExtractor:
     def __init__(
         self,
         records_data: Optional[Dict[str, Any]] = None,
-        crawler: Optional[KaggleCrawler] = None,
         models_client: Optional[KaggleModelClient] = None,
         instances_client: Optional[KaggleInstancesClient] = None,
-        licenses_client: Optional[KaggleLicenseClient] = None,
         keywords_client: Optional[KaggleKeywordsClient] = None,
+        licenses_client: Optional[KaggleLicenseClient] = None,
         frameworks_client: Optional[KaggleFrameworkClient] = None,
+        sharedby_client: Optional[KaggleSharedByClient] = None,
+        crawler: Optional[KaggleCrawler] = None,
     ) -> None:
         self.models_client = models_client or KaggleModelClient(records_data)
-        self.crawler = crawler
         self.instances_client = instances_client or KaggleInstancesClient(records_data)
-        self.licenses_client = licenses_client or KaggleLicenseClient(records_data)
         self.keywords_client = keywords_client or KaggleKeywordsClient(records_data)
+        self.licenses_client = licenses_client or KaggleLicenseClient(records_data)
         self.frameworks_client = frameworks_client or KaggleFrameworkClient(records_data)
+        self.sharedby_client = sharedby_client or KaggleSharedByClient(records_data)
+        self.crawler = crawler
 
     def fetch_records(
         self,
@@ -94,19 +97,23 @@ class KaggleExtractor:
     def extract_models(self) -> pd.DataFrame:
         df = self.models_client.get_models_metadata()
         return df
-    
+
     def extract_specific_instances(self, instance_ids) -> pd.DataFrame:
         df = self.instances_client.get_instances_metadata(instance_ids)
         return df
-    
+
+    def extract_specific_keywords(self, keyword_names) -> pd.DataFrame:
+        df = self.keywords_client.get_keywords_metadata(keyword_names)
+        return df
+
     def extract_specific_licenses(self, license_names) -> pd.DataFrame:
         df = self.licenses_client.get_licenses_metadata(license_names)
         return df
-    
-    def extract_specific_keywords(self, keywords_names) -> pd.DataFrame:
-            df = self.keywords_client.get_keywords_metadata(keywords_names)
-            return df
-        
-    def extract_specific_frameworks(self, frameworks_names) -> pd.DataFrame:
-                df = self.frameworks_client.get_frameworks_metadata(frameworks_names)
-                return df
+
+    def extract_specific_frameworks(self, framework_names) -> pd.DataFrame:
+        df = self.frameworks_client.get_frameworks_metadata(framework_names)
+        return df
+
+    def extract_sharedby(self, names) -> pd.DataFrame:
+        df = self.sharedby_client.get_sharedby_metadata(names)
+        return df

--- a/etl_extractors/kaggle/kaggle_extractor.py
+++ b/etl_extractors/kaggle/kaggle_extractor.py
@@ -8,6 +8,10 @@ import pandas as pd
 
 from etl_extractors.kaggle.clients.models_client import KaggleModelClient
 from etl_extractors.kaggle.clients.instances_client import KaggleInstancesClient
+from etl_extractors.kaggle.clients.licenses_client import KaggleLicenseClient
+from etl_extractors.kaggle.clients.keywords_client import KaggleKeywordsClient
+from etl_extractors.kaggle.clients.frameworks_client import KaggleFrameworkClient
+
 from etl_extractors.kaggle.kaggle_crawler import KaggleCrawler
 
 logger = logging.getLogger(__name__)
@@ -26,13 +30,19 @@ class KaggleExtractor:
     def __init__(
         self,
         records_data: Optional[Dict[str, Any]] = None,
+        crawler: Optional[KaggleCrawler] = None,
         models_client: Optional[KaggleModelClient] = None,
         instances_client: Optional[KaggleInstancesClient] = None,
-        crawler: Optional[KaggleCrawler] = None,
+        licenses_client: Optional[KaggleLicenseClient] = None,
+        keywords_client: Optional[KaggleKeywordsClient] = None,
+        frameworks_client: Optional[KaggleFrameworkClient] = None,
     ) -> None:
         self.models_client = models_client or KaggleModelClient(records_data)
         self.crawler = crawler
         self.instances_client = instances_client or KaggleInstancesClient(records_data)
+        self.licenses_client = licenses_client or KaggleLicenseClient(records_data)
+        self.keywords_client = keywords_client or KaggleKeywordsClient(records_data)
+        self.frameworks_client = frameworks_client or KaggleFrameworkClient(records_data)
 
     def fetch_records(
         self,
@@ -88,3 +98,15 @@ class KaggleExtractor:
     def extract_specific_instances(self, instance_ids) -> pd.DataFrame:
         df = self.instances_client.get_instances_metadata(instance_ids)
         return df
+    
+    def extract_specific_licenses(self, license_names) -> pd.DataFrame:
+        df = self.licenses_client.get_licenses_metadata(license_names)
+        return df
+    
+    def extract_specific_keywords(self, keywords_names) -> pd.DataFrame:
+            df = self.keywords_client.get_keywords_metadata(keywords_names)
+            return df
+        
+    def extract_specific_frameworks(self, frameworks_names) -> pd.DataFrame:
+                df = self.frameworks_client.get_frameworks_metadata(frameworks_names)
+                return df

--- a/etl_extractors/kaggle/kaggle_helper.py
+++ b/etl_extractors/kaggle/kaggle_helper.py
@@ -1,0 +1,236 @@
+"""
+Helper utilities for Kaggle extraction and enrichment.
+
+Contains commonly used functions shared across Kaggle extractors, enrichment, and assets.
+"""
+
+from __future__ import annotations
+import hashlib
+import json
+from pathlib import Path
+import logging
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleHelper:
+    """
+    Helper class containing common utility functions for Kaggle data processing.
+
+    This class provides static methods for common operations like loading
+    dataframes from JSON files, validating data, and other shared utilities.
+    """
+
+    @staticmethod
+    def load_models_dataframe(models_json_path: Path | str) -> pd.DataFrame:
+        """
+        Load models JSON into a DataFrame with robust handling.
+
+        Supports both array JSON (e.g., [ {...}, {...} ]) and JSON Lines (NDJSON).
+        Both matter here: the crawler writes NDJSON as its append-only log and
+        a deduplicated array as its final output, so either may be handed in.
+
+        Args:
+            models_json_path: Path to the JSON file containing model metadata
+
+        Returns:
+            DataFrame containing the model data
+
+        Raises:
+            FileNotFoundError: If the file does not exist
+            ValueError: If the file is a directory, empty, or invalid JSON format
+        """
+        path = Path(models_json_path)
+
+        if not path.exists():
+            raise FileNotFoundError(f"Models JSON not found at: {path}")
+        if path.is_dir():
+            raise ValueError(f"Expected a file but got a directory: {path}")
+        if path.stat().st_size == 0:
+            raise ValueError(f"Models JSON is empty: {path}")
+
+        # NDJSON first when the suffix says so - the crawler's log is large and
+        # trying array-parse on it first is wasted work.
+        if path.suffix.lower() in (".ndjson", ".jsonl"):
+            try:
+                df = pd.read_json(path, orient="records", lines=True)
+                if not df.empty or len(df.columns) > 0:
+                    logger.debug(f"Loaded {len(df)} records from {path} (JSON Lines)")
+                    return df
+            except ValueError:
+                pass
+
+        # First attempt: array JSON via pandas
+        try:
+            df = pd.read_json(path, orient="records")
+            if not df.empty or len(df.columns) > 0:
+                logger.debug(f"Loaded {len(df)} records from {path} (array JSON)")
+                return df
+        except ValueError:
+            pass
+
+        # Second attempt: JSON Lines via pandas
+        try:
+            df = pd.read_json(path, orient="records", lines=True)
+            if not df.empty or len(df.columns) > 0:
+                logger.debug(f"Loaded {len(df)} records from {path} (JSON Lines)")
+                return df
+        except ValueError:
+            pass
+
+        # If both pandas attempts fail, raise clear error
+        raise ValueError(
+            f"Failed to parse models JSON at {path}. "
+            "File must be valid JSON array or JSON Lines format."
+        )
+
+    @staticmethod
+    def get_model_id_column(df: pd.DataFrame) -> str:
+        """
+        Determine the model ID column name in a DataFrame.
+
+        Kaggle's raw records key on ``ref`` (owner/slug); normalized records
+        use ``modelId``.
+
+        Args:
+            df: DataFrame containing model data
+
+        Returns:
+            Name of the ID column ('modelId', 'ref', or 'id')
+
+        Raises:
+            ValueError: If no recognized ID column is found
+        """
+        for candidate in ("modelId", "ref", "id"):
+            if candidate in df.columns:
+                return candidate
+        raise ValueError("DataFrame must contain a 'modelId', 'ref', or 'id' column")
+
+    @staticmethod
+    def deduplicate_models(df: pd.DataFrame, id_column: str | None = None) -> pd.DataFrame:
+        """
+        Remove duplicate models from a DataFrame based on model ID.
+
+        Incremental runs append a fresh record for changed models, so the
+        LAST occurrence is the current one - note this keeps "last", unlike
+        the AI4Life equivalent which keeps "first".
+
+        Args:
+            df: DataFrame containing model data
+            id_column: Name of the ID column (if None, auto-detected)
+
+        Returns:
+            DataFrame with duplicates removed
+        """
+        if id_column is None:
+            try:
+                id_column = KaggleHelper.get_model_id_column(df)
+            except ValueError:
+                logger.warning("No ID column found, returning DataFrame unchanged")
+                return df
+
+        if id_column not in df.columns:
+            logger.warning(f"Column '{id_column}' not found, returning DataFrame unchanged")
+            return df
+
+        before_count = len(df)
+        df = df.drop_duplicates(subset=[id_column], keep="last")
+        after_count = len(df)
+
+        if after_count != before_count:
+            logger.info(
+                f"Removed {before_count - after_count} duplicate models "
+                f"(before: {before_count}, after: {after_count})"
+            )
+
+        return df
+
+    @staticmethod
+    def generate_mlentory_entity_hash_id(entity_type: str, entity_id: str, platform: str = "Kaggle") -> str:
+        """
+        Generate a consistent hash from entity properties.
+
+        Must stay byte-identical to the other platform helpers so entity IDs
+        reconcile across the graph - same key order, same separators, same
+        w3id prefix. Only the default platform differs.
+
+        Args:
+            entity_type (str): The type of entity (e.g., 'Dataset', 'Model', 'Article')
+            entity_id (str): The unique identifier for the entity
+            platform (str): The platform name (default: 'Kaggle')
+
+        Returns:
+            str: A SHA-256 hash of the concatenated properties (mlentory_id)
+
+        Example:
+            >>> hash_value = KaggleHelper.generate_mlentory_entity_hash_id('Model', 'google/gemma')
+            >>> print(hash_value)
+            'https://w3id.org/mlentory/mlentory_graph/...'
+        """
+        # Create a sorted dictionary of properties to ensure consistent hashing
+        properties = {
+            "platform": platform,
+            "type": entity_type,
+            "id": entity_id
+        }
+
+        # Convert to JSON string to ensure consistent serialization
+        properties_str = json.dumps(properties, sort_keys=True)
+
+        # Generate SHA-256 hash
+        hash_obj = hashlib.sha256(properties_str.encode())
+        return "https://w3id.org/mlentory/mlentory_graph/"+hash_obj.hexdigest()
+
+    @staticmethod
+    def raw_kaggle_catalog_website_records() -> list[dict[str, object]]:
+        """
+        Canonical Kaggle hosting ``schema:WebSite`` row(s) for this pipeline.
+
+        Minted with :meth:`generate_mlentory_entity_hash_id` like other Kaggle entities.
+        Intended to be written as ``sources.json`` under ``1_raw/kaggle/<run>/`` at extract.
+        """
+        url = "https://www.kaggle.com/models"
+        mlentory_id = KaggleHelper.generate_mlentory_entity_hash_id("WebSite", url)
+        return [
+            {
+                "https://schema.org/identifier": [mlentory_id],
+                "https://schema.org/name": "Kaggle",
+                "https://schema.org/url": url,
+            }
+        ]
+
+    @staticmethod
+    def resolve_abstract_content(raw_model: Dict[str, Any]) -> Optional[str]:
+        """
+        Resolve schema:abstract content for a Kaggle model.
+
+        Unlike AI4Life, no network call is needed: Kaggle serves the model
+        card inline as ``description`` on the models/get response, which the
+        crawler has already persisted. Falls back to ``subtitle`` when a
+        model has no description.
+        """
+        for field in ("documentation_content", "description", "intendedUse", "subtitle"):
+            value = str(raw_model.get(field, "") or "").strip()
+            if value:
+                return value
+        return None
+
+    @staticmethod
+    def attach_documentation(models: List[Dict[str, Any]]) -> None:
+        """
+        Attach ``documentation_content`` to each model from its inline card.
+
+        Present for parity with the AI4Life helper, but no fetching occurs -
+        the content already arrived with the record.
+        """
+        if not models:
+            return
+        for model in models:
+            if not isinstance(model, dict):
+                continue
+            if str(model.get("documentation_content", "")).strip():
+                continue
+            model["documentation_content"] = KaggleHelper.resolve_abstract_content(model) or ""

--- a/etl_loaders/rdf_loader.py
+++ b/etl_loaders/rdf_loader.py
@@ -50,6 +50,7 @@ def build_model_triples(graph: Graph, model: Dict[str, Any]) -> int:
     # Add rdf:type
     graph.add((subject, namespaces["rdf"].type, namespaces["fair4ml"].MLModel))
     
+    
     string_properties_lst = [
         # Core identification properties
         "https://schema.org/identifier",

--- a/etl_transformers/common/entity_link_metadata.py
+++ b/etl_transformers/common/entity_link_metadata.py
@@ -80,9 +80,38 @@ AI4LIFE_ENTITY_LINK_METADATA: Dict[str, Dict[str, Any]] = {
     ),
 }
 
+# Field → metadata for Kaggle entity-linking merge (merge_kaggle_partial_schemas).
+# Paste into etl_transformers/common/entity_link_metadata.py alongside the
+# HF and AI4Life dicts, then register it in _PLATFORM_METADATA below.
+KAGGLE_ENTITY_LINK_METADATA: Dict[str, Dict[str, Any]] = {
+    "license": _entry(
+        "kaggle_license_identifier",
+        source_field="licenses",
+        notes="License is declared per model instance, not per model",
+    ),
+    "source": _entry(
+        "Kaggle_catalog_website",
+        source_field="sources",
+        notes="Kaggle catalog WebSite IRI",
+    ),
+    "keywords": _entry(
+        "Kaggle_models_endpoint",
+        source_field="keywords",
+        notes="Curated Kaggle tags; sparse coverage across the catalog",
+    ),
+    "modelCategory": _entry(
+        "kaggle_framework_identifier",
+        source_field="frameworks",
+        notes="Framework names read from instance URLs (PyTorch, Keras, …)",
+    ),
+}
+ 
+ 
+# Add "kaggle" to the existing registry:
 _PLATFORM_METADATA: Dict[str, Dict[str, Dict[str, Any]]] = {
     "hf": HF_ENTITY_LINK_METADATA,
     "ai4life": AI4LIFE_ENTITY_LINK_METADATA,
+    "kaggle": KAGGLE_ENTITY_LINK_METADATA,
 }
 
 

--- a/etl_transformers/common/entity_link_metadata.py
+++ b/etl_transformers/common/entity_link_metadata.py
@@ -81,8 +81,6 @@ AI4LIFE_ENTITY_LINK_METADATA: Dict[str, Dict[str, Any]] = {
 }
 
 # Field → metadata for Kaggle entity-linking merge (merge_kaggle_partial_schemas).
-# Paste into etl_transformers/common/entity_link_metadata.py alongside the
-# HF and AI4Life dicts, then register it in _PLATFORM_METADATA below.
 KAGGLE_ENTITY_LINK_METADATA: Dict[str, Dict[str, Any]] = {
     "license": _entry(
         "kaggle_license_identifier",
@@ -99,15 +97,26 @@ KAGGLE_ENTITY_LINK_METADATA: Dict[str, Dict[str, Any]] = {
         source_field="keywords",
         notes="Curated Kaggle tags; sparse coverage across the catalog",
     ),
-    "modelCategory": _entry(
+    "mlTask": _entry(
+        "kaggle_keyword_identifier",
+        source_field="keywords",
+        notes="Derived from tags under the 'task' category in fullPath",
+    ),
+    "sharedBy": _entry("kaggle_sharedby_identifier", source_field="sharedBy"),
+    "softwareRequirements": _entry(
         "kaggle_framework_identifier",
         source_field="frameworks",
         notes="Framework names read from instance URLs (PyTorch, Keras, …)",
     ),
+    "inLanguage": _entry(
+        "lingua-language-detector+pycountry",
+        source_field="intendedUse",
+        notes="Model card language detection",
+    ),
 }
- 
- 
-# Add "kaggle" to the existing registry:
+
+
+# Add to the platform registry:
 _PLATFORM_METADATA: Dict[str, Dict[str, Dict[str, Any]]] = {
     "hf": HF_ENTITY_LINK_METADATA,
     "ai4life": AI4LIFE_ENTITY_LINK_METADATA,

--- a/etl_transformers/kaggle/__init__.py
+++ b/etl_transformers/kaggle/__init__.py
@@ -1,0 +1,11 @@
+"""Kaggle to FAIR4ML transformation modules."""
+
+from .transform_mlmodel import (
+    map_kaggle_basic_properties,
+    normalize_kaggle_model
+)
+
+__all__ = [
+    "map_kaggle_basic_properties",
+    "normalize_kaggle_model"
+]

--- a/etl_transformers/kaggle/transform_mlmodel.py
+++ b/etl_transformers/kaggle/transform_mlmodel.py
@@ -273,18 +273,9 @@ def map_kaggle_basic_properties(raw_model: Dict[str, Any]) -> Dict[str, Any]:
     # Total uncompressed bytes summed across the model's instances.
     memory_requirements = str(raw_model.get("contentSize", "")).strip()
 
-    # Platform-specific counters, kept out of the FAIR fields proper.
-    metrics: Dict[str, Any] = {}
-    for source_key, target_key in (
-        ("voteCount", "votes"),
-        ("downloadCount", "downloads"),
-        ("num_instances", "instances"),
-    ):
-        value = raw_model.get(source_key)
-        if isinstance(value, (int, float)):
-            metrics[target_key] = value
-        elif isinstance(value, str) and value.strip().isdigit():
-            metrics[target_key] = int(value.strip())
+    # Kaggle sets fineTunable on the instance, never on the model, so a parent
+    # model has nothing to read here. Its instances carry their own value.
+    adaption_techniques = "fineTuned" if raw_model.get("fineTunable") else None
 
     # Build the result FIRST
     result: Dict[str, Any] = {
@@ -307,7 +298,7 @@ def map_kaggle_basic_properties(raw_model: Dict[str, Any]) -> Dict[str, Any]:
         "readme": readme,
         "issueTracker": issue_tracker,
         "memoryRequirements": memory_requirements,
-        "metrics": metrics,
+        "adaptionTechniques": adaption_techniques,
         "_model_id": model_id,
     }
 
@@ -415,11 +406,11 @@ def map_kaggle_basic_properties(raw_model: Dict[str, Any]) -> Dict[str, Any]:
             source_field="contentSize",
             notes="Uncompressed bytes summed across all model instances",
         ),
-        "metrics": _create_extraction_metadata(
+        "adaptionTechniques": _create_extraction_metadata(
             method=_METHOD,
             confidence=1.0,
-            source_field="voteCount, downloadCount, num_instances",
-            notes="Platform-specific counters; non-FAIR extension",
+            source_field="fineTunable",
+            notes="Set per instance by Kaggle; absent on the model itself",
         ),
         "citation": _create_extraction_metadata(
             method=_METHOD,

--- a/etl_transformers/kaggle/transform_mlmodel.py
+++ b/etl_transformers/kaggle/transform_mlmodel.py
@@ -1,0 +1,473 @@
+"""
+Kaggle to FAIR4ML MLModel transformation functions.
+
+This module provides modular mapping functions that transform raw Kaggle
+model metadata into FAIR4ML-compliant MLModel objects.
+
+Each mapping function handles a specific group of related properties and returns
+a dictionary with the mapped fields plus extraction metadata for provenance tracking.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+import json
+import logging
+
+from etl_extractors.kaggle.kaggle_helper import KaggleHelper
+from etl_transformers.common.citation_text import (
+    parse_creative_work_citations_from_text,
+)
+from etl_transformers.common.utils import (
+    extract_normalized_doi,
+    build_identifier,
+    build_model_urls,
+    validate_optional_url,
+)
+from schemas.fair4ml import MLModel, ExtractionMetadata
+
+
+logger = logging.getLogger(__name__)
+
+_METHOD = "Parsed_from_Kaggle_models_json"
+
+
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    """
+    Parse a datetime value from various formats.
+
+    Args:
+        value: Input value (string, datetime, or None)
+
+    Returns:
+        Parsed datetime or None
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        return value
+
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        try:
+            # Try parsing ISO format
+            return datetime.fromisoformat(cleaned.replace('Z', '+00:00'))
+        except (ValueError, AttributeError):
+            logger.warning(f"Could not parse datetime: {value}")
+            return None
+
+    return None
+
+
+def _create_extraction_metadata(
+    method: str,
+    confidence: float = 1.0,
+    source_field: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> ExtractionMetadata:
+    """
+    Create extraction metadata for a field.
+
+    Args:
+        method: Extraction method description
+        confidence: Confidence score (0.0 to 1.0)
+        source_field: Name of source field in raw data
+        notes: Additional notes
+
+    Returns:
+        ExtractionMetadata object
+    """
+    return ExtractionMetadata(
+        extraction_method=method,
+        confidence=confidence,
+        source_field=source_field,
+        notes=notes,
+    )
+
+
+def _safe_json_loads(value: Any, default: Any):
+    if value is None:
+        return default
+    if isinstance(value, (list, dict)):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return default
+        try:
+            return json.loads(s)
+        except Exception:
+            return default
+    return default
+
+
+def _pick_first_author_name(raw_author_field: Any) -> str:
+    # If it's already a normal string, return it
+    if isinstance(raw_author_field, str):
+        s = raw_author_field.strip()
+        # If it looks like JSON, try to parse; otherwise treat it as the author name
+        if not s.startswith("[") and not s.startswith("{"):
+            return s
+
+    authors = _safe_json_loads(raw_author_field, default=[])
+
+    # Some sources might give dict instead of list
+    if isinstance(authors, dict):
+        name = str(authors.get("name", "")).strip()
+        return name
+
+    if isinstance(authors, list) and authors:
+        a0 = authors[0]
+        if isinstance(a0, dict):
+            return str(a0.get("name", "")).strip()
+        if isinstance(a0, str):
+            return a0.strip()
+
+    return ""
+
+
+def _as_str_list(value: Any, fallback: Any = None) -> List[str]:
+    """
+    Coerce a value into a list of non-empty strings.
+
+    Extraction writes multi-valued fields as JSON arrays; the fallback is the
+    joined display string, split on ", " only as a last resort for rows
+    written before the array existed.
+    """
+    items = _safe_json_loads(value, default=None)
+    if isinstance(items, list):
+        out = [str(v).strip() for v in items if str(v).strip()]
+        if out:
+            return out
+
+    text = str(fallback or "").strip()
+    if not text:
+        return []
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+def _split_reference_publication(value: Any) -> List[str]:
+    """
+    Split Kaggle's provenanceSources block into individual references.
+
+    The field is free text; well-documented models use a newline-separated
+    markdown list of links, while others put a sentence there. Bullet markers
+    are stripped and blank lines dropped.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return []
+    out: List[str] = []
+    for line in text.splitlines():
+        cleaned = line.strip().lstrip("-*").strip()
+        if cleaned and cleaned not in out:
+            out.append(cleaned)
+    return out
+
+
+def _pick_archived_at(raw_archived_at: Any, fallback: str) -> str:
+    """
+    archivedAt is a JSON array string in the extracted data.
+    Pick the first archived URL if present, otherwise fall back to `url`.
+    """
+    items = _safe_json_loads(raw_archived_at, default=[])
+    if isinstance(items, list):
+        for it in items:
+            if isinstance(it, str) and it.strip():
+                return it.strip()
+            if isinstance(it, dict):
+                u = it.get("url") or it.get("href")
+                if isinstance(u, str) and u.strip():
+                    return u.strip()
+    return fallback
+
+
+def normalize_citations_from_kaggle_raw(raw_model: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Build schema.org citation dicts from a Kaggle model record.
+
+    Kaggle has no citation field. ``provenanceSources`` is a free-text block -
+    for well-documented models a newline-separated list of paper and repository
+    links - and the model card itself often carries a BibTeX entry. Both are
+    scanned; the shared parser only emits a CreativeWork when it finds a
+    resolvable DOI, so records without one yield an empty list rather than a
+    citation with no ``@id``.
+    """
+    parts = [
+        str(raw_model.get("referencePublication", "") or "").strip(),
+        str(raw_model.get("citation", "") or "").strip(),
+        str(raw_model.get("intendedUse", "") or "").strip(),
+    ]
+    text = "\n\n".join(part for part in parts if part)
+    if not text:
+        return []
+
+    return parse_creative_work_citations_from_text(
+        text,
+        max_works=5,
+        log_context=str(raw_model.get("modelId", "")).strip() or None,
+    )
+
+
+def map_kaggle_basic_properties(raw_model: Dict[str, Any]) -> Dict[str, Any]:
+    model_id = str(raw_model.get("modelId", "")).strip()
+    url = str(raw_model.get("url", "")).strip()
+    mlentory_id = str(raw_model.get("mlentory_id", "")).strip()
+
+    doi = extract_normalized_doi(
+        raw_record=raw_model,
+        candidate_fields=("doi", "DOI", "referencePublication", "reference_publication"),
+    )
+    identifier: List[str] = build_identifier(doi=doi, mlentory_id=mlentory_id)
+    urls: List[str] = build_model_urls(platform_url=url, mlentory_id=mlentory_id)
+
+    name = str(raw_model.get("name", "")).strip() or model_id
+    shared_by = str(raw_model.get("sharedBy", "")).strip()
+    author = _pick_first_author_name(raw_model.get("author")) or shared_by
+
+    # modelCategory is List[str] in the schema. Kaggle reports the instance
+    # framework here, so the structured `frameworks` array is preferred over
+    # the joined `modelArchitecture` display string.
+    modelCategory = _as_str_list(
+        raw_model.get("frameworks"), fallback=raw_model.get("modelArchitecture")
+    )
+    intentedUse = str(raw_model.get("intendedUse", "")).strip()
+    citation = normalize_citations_from_kaggle_raw(raw_model)
+
+    # provenanceSources is a free-text block, often a newline-separated list
+    # of paper and repository links.
+    reference_publication = _split_reference_publication(
+        raw_model.get("referencePublication")
+    )
+
+    date_created = str(raw_model.get("dateCreated", "")).strip()
+    date_modified = str(raw_model.get("dateModified", "")).strip()
+    # Kaggle returns publishTime on only a minority of records, so dateCreated
+    # is usually empty while dateModified (from updateTime) is reliable. Fall
+    # back to dateModified rather than leaving datePublished unset.
+    date_published = (
+        str(raw_model.get("datePublished", "")).strip()
+        or date_created
+        or date_modified
+    )
+
+    # Parse dates
+    date_created = _parse_datetime(date_created)
+    date_modified = _parse_datetime(date_modified)
+
+    description = str(raw_model.get("intendedUse", "")).strip()
+    readme = validate_optional_url(raw_model.get("readme_file"))
+    # No network call: Kaggle serves the model card inline as the description,
+    # which extraction already persisted.
+    abstract = KaggleHelper.resolve_abstract_content(raw_model)
+    archived_at = _pick_archived_at(raw_model.get("archivedAt"), fallback=url)
+
+    # Optional fields (not present in the Kaggle models endpoint)
+    discussion_url = str(raw_model.get("discussionUrl", "")).strip()
+    issue_tracker = str(raw_model.get("issueTracker", "")).strip()
+
+    # Total uncompressed bytes summed across the model's instances.
+    memory_requirements = str(raw_model.get("contentSize", "")).strip()
+
+    # Platform-specific counters, kept out of the FAIR fields proper.
+    metrics: Dict[str, Any] = {}
+    for source_key, target_key in (
+        ("voteCount", "votes"),
+        ("downloadCount", "downloads"),
+        ("num_instances", "instances"),
+    ):
+        value = raw_model.get(source_key)
+        if isinstance(value, (int, float)):
+            metrics[target_key] = value
+        elif isinstance(value, str) and value.strip().isdigit():
+            metrics[target_key] = int(value.strip())
+
+    # Build the result FIRST
+    result: Dict[str, Any] = {
+        "identifier": identifier,
+        "name": name,
+        "url": urls,
+        "author": author,
+        "sharedBy": shared_by,
+        "modelCategory": modelCategory,
+        "referencePublication": reference_publication,
+        "citation": citation,
+        "intendedUse": intentedUse,
+        "dateCreated": date_created,
+        "dateModified": date_modified,
+        "datePublished": date_published,
+        "description": description,
+        "abstract": abstract,
+        "discussionUrl": discussion_url,
+        "archivedAt": archived_at,
+        "readme": readme,
+        "issueTracker": issue_tracker,
+        "memoryRequirements": memory_requirements,
+        "metrics": metrics,
+        "_model_id": model_id,
+    }
+
+    # Build extraction metadata (Kaggle fields)
+    result["extraction_metadata"] = {
+        "identifier": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="doi, referencePublication, mlentory_id",
+            notes="Contains only DOI (if present) and mlentory_id",
+        ),
+        "name": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="name",
+            notes="Kaggle model title; fallback to modelId if missing",
+        ),
+        "url": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="url, mlentory_id",
+            notes="Contains platform URL and MLentory UI URL",
+        ),
+        "author": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="author",
+            notes="Parsed from JSON string; fallback to sharedBy",
+        ),
+        "sharedBy": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="sharedBy",
+            notes="Kaggle model owner (user or organization)",
+        ),
+        "dateCreated": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="dateCreated",
+            notes="From publishTime; absent on most Kaggle records",
+        ),
+        "dateModified": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="dateModified",
+            notes="From updateTime",
+        ),
+        "datePublished": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="datePublished",
+            notes="Fallback to dateCreated, then dateModified",
+        ),
+        "description": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="intendedUse",
+            notes=None,
+        ),
+        "abstract": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="description",
+            notes="Model card served inline by Kaggle; no separate fetch",
+        ),
+        "discussionUrl": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="discussionUrl",
+            notes="Not returned by the Kaggle models endpoint",
+        ),
+        "archivedAt": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="archivedAt",
+            notes="First archivedAt URL if list; fallback to url",
+        ),
+        "readme": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="readme_file",
+            notes="Kaggle has no separate readme URL; card is inline",
+        ),
+        "issueTracker": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="issueTracker",
+            notes="Not returned by the Kaggle models endpoint",
+        ),
+        "modelCategory": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="frameworks, modelArchitecture",
+            notes="Kaggle reports the instance framework, not an architecture",
+        ),
+        "referencePublication": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="referencePublication",
+            notes="Split from the provenanceSources free-text block",
+        ),
+        "memoryRequirements": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="contentSize",
+            notes="Uncompressed bytes summed across all model instances",
+        ),
+        "metrics": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="voteCount, downloadCount, num_instances",
+            notes="Platform-specific counters; non-FAIR extension",
+        ),
+        "citation": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="referencePublication, citation, intendedUse",
+            notes=(
+                "Parsed from provenanceSources and model card text; only DOIs "
+                "yield a CreativeWork, so most Kaggle records produce none"
+            ),
+        ),
+        "intendedUse": _create_extraction_metadata(
+            method=_METHOD,
+            confidence=1.0,
+            source_field="intendedUse",
+            notes="Kaggle model card description",
+        ),
+    }
+
+    return result
+
+
+def normalize_kaggle_model(raw_model: Dict[str, Any]) -> MLModel:
+    """
+    Normalize a raw Kaggle model record into a FAIR4ML MLModel object.
+
+    This is the main entry point that orchestrates all mapping functions.
+    Currently implements only basic properties; additional mapping functions
+    will be added for keywords, licenses, frameworks, instances, etc.
+
+    Args:
+        raw_model: Dictionary containing raw Kaggle model data
+
+    Returns:
+        Validated MLModel instance
+
+    Raises:
+        ValidationError: If the mapped data doesn't conform to the schema
+    """
+    # Start with basic properties
+    mapped_data = map_kaggle_basic_properties(raw_model)
+
+    # TODO: Add more mapping functions:
+    # - map_keywords(raw_model) for tags -> keywords
+    # - map_license(raw_model) for licenses -> license
+    # - map_frameworks(raw_model) for frameworks -> mlTask / softwareRequirements
+    # - map_instances(raw_model) for instance entities
+    # - map_lineage(raw_model) for baseModelInstanceInformation -> baseModel
+    # - map_datasets(raw_model) for trainedOn -> trainingData
+
+    # Validate and return
+    return MLModel(**mapped_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ langchain-openai = "0.3.5"
 SPARQLWrapper = "^2.0.0"
 faiss-cpu = "^1.7.4"
 lingua-language-detector = ">=1.4.2,<2"
-
+kaggle = { version = ">=2.2.2,<3", python = ">=3.11" }
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "-ra -q --strict-markers --tb=short"


### PR DESCRIPTION

# Add Kaggle extractor (extraction + enrichment, 1 commit), Integrating model instances entity identifier, 2nd commit)

Adds Kaggle as a platform in the ETL pipeline, following the AI4Life structure:
a thin extractor delegating to per-entity clients, entity identifiers for
related entities, and a Dagster asset graph rooted at a timestamped run folder.

## Extraction

**`kaggle_run_folder`** → **`kaggle_model_refs`** → **`kaggle_raw_records`** → **`kaggle_models_raw`**
plus **`kaggle_raw_catalog_sources`** for provenance.

Kaggle differs from the other platforms in one important way: there is no
endpoint that returns many models at once. Every model card needs its own API
call, and there are ~43,000 of them. `kaggle_model_refs` derives the model list
by joining Meta Kaggle's `Models.csv` against `Organizations.csv` and
`Users.csv`; `kaggle_raw_records` then crawls the API for each ref.

That crawl is handled by `KaggleCrawler`, which is the one file with no AI4Life
analogue. It provides parallel fetching, adaptive rate limiting, crash-resume,
and incremental refresh. Keeping it separate leaves `KaggleExtractor` the same
shape and size as `AI4LifeExtractor`.

### Performance

Full extraction runs in **~6 hours**, down from ~2 days for a naive sequential
crawl — roughly a 10× improvement. The remaining limit is Kaggle's, not ours:
the API enforces a rolling hourly quota of roughly 7–9k records on this
endpoint. This was measured rather than assumed — throttling occurs even at 0.5
req/s, which rules out a per-second speed cap, and several configurations all
converged on the same hourly total. Rate limits are therefore class constants in
`KaggleCrawler` rather than config values, with a comment explaining why raising
them does not help.

Data quality on the full run: 22 failures out of ~43,000 (0.05%), all deleted or
renamed models. 600+ rate-limit events, all automatically retried and recovered,
zero records lost.

### Resume and incremental

Records are appended to an NDJSON log and fsynced every 200 rows, so an
interrupted run continues from its last checkpoint rather than starting over.
This was validated in production during a mid-crawl restart at 10,500 records
with no data loss.

Subsequent runs fingerprint Meta Kaggle's date/version columns and fetch only
new or changed models — typically ~1,000 records, about 10 minutes instead of 6
hours.

Because resume and incremental both depend on reading what previous runs
collected, that state lives under `CACHE_PATH` (`/data/cache/kaggle/`) rather
than inside the run folder. A per-run location would reset it every time and
turn every run into a fresh multi-hour crawl. Run folders under
`/data/1_raw/kaggle/<timestamp>_<uuid>/` still receive the full output of each
run: `records.json`, `models.json`, `instances.json`, `keywords.json`,
`sources.json`.

## Enrichment

Two entity types, both following the `identified_*` → `*_raw` pattern used for
AI4Life datasets and keywords.

### Instances

A Kaggle model is a container; the downloadable artifacts are its *instances*,
one per framework and variation. `google/bert` has 31, each with its own
license, version, size and URL. Flattening those onto the model row would lose
which framework belongs to which variation, so they are emitted as their own
entities linked back by `parent_mlentory_id`.

Instance ids mirror the Kaggle URL path
(`google/bert/TensorFlow2/answer-equivalence-bem`) so they round-trip to a real
page. This matters: Kaggle's `framework` field is inconsistent across records —
`pyTorch`, `keras`, and `MODEL_FRAMEWORK_TENSOR_FLOW_2` all appear — while the
URL always carries the display form. Both are kept, `modelArchitecture` for the
raw value and `frameworkName` for the display form.

Every raw instance field is passed through alongside the schema-aligned ones, so
fields Kaggle adds later are not silently dropped. This already surfaced
`baseModelInstanceInformation`, a nested object carrying model lineage for
fine-tuned instances, which is worth mapping into the graph in a follow-up.

### To run the extraction
#### Kaggle Configuration
 ```
 kaggle:
    # Number of models to extract. null = all (~43,044)
    num_models: null
    # Fetch only new/changed models since the last run.
    # Keep false for the baseline crawl; switch to true afterwards.
    incremental: false
    # Force a full refetch regardless of state
    force_full_refresh: false
    # Re-download Meta Kaggle CSVs to pick up new models (daily refresh)
    refresh_metadata: true
    # Parallel threads. Throughput is capped by Kaggle's hourly quota,
    # not by this value - raising it does not make the crawl faster.
    threads: 8
```

#### Output files are below to review:
[instances.json](https://github.com/user-attachments/files/31034535/instances.json)
[Kaggle_models.json](https://github.com/user-attachments/files/31034537/Kaggle_models.json)
[records.json](https://github.com/user-attachments/files/31034538/records.json)




## Recent changes

### Models and instances in one file

`mlmodels.json` now holds both models and their instances as separate
`MLModel` records, rather than splitting instances into `mlinstances.json`.
A Kaggle model is a container and its instances are the downloadable
artifacts — one per framework and variation — and each is a model in its own
right.

Instances are identifiable by a populated `baseModel`: on an instance it
points at the model it belongs to, and additionally at the model it was
derived from where Kaggle records real lineage. Parent models have an empty
`baseModel`, since Kaggle records lineage per instance only.

The `kaggle_instances_normalized` and `kaggle_load_instances_to_neo4j` assets
are removed; instance normalization now happens inside
`kaggle_model_normalized`.

Note this means models and instances share the `fair4ml:MLModel` type in the
graph. `schema:isPartOf` would separate "packaged from" from "derived from"
properly, but that needs a line in the shared `rdf_loader.build_model_triples`
property list — raised separately rather than done here.

### `adaptionTechniques`

Added to both models and instances, set to `"fineTuned"` where Kaggle's
`fineTunable` flag is present and `None` otherwise. The flag is declared per
instance, so parent models resolve to `None`.

### `sharedBy` entity

New identifier and client pair, following the same shape as licenses,
keywords, and frameworks. On Kaggle this is the account that uploaded the
model — a user or an organization — so grouping by it answers "show me
everything this account published".

Entities are de-duplicated by name: one node, many edges. The value stored on
a model is the minted `mlentory_id`, not the display name; the readable form
comes from `translation_mapping.json`, matching how the HF pipeline renders
it.

Instances inherit their parent's `sharedBy` rather than being left empty, so a
search for an account's work returns the variations alongside the models. The
IRI is minted in the merge step for instances, since entity linking only
covers `models.json` — verified byte-identical to the model's, so both point
at one node rather than a name and an IRI diverging.

Two details worth noting from testing: pandas turns missing cells into float
`nan`, whose `str()` is `"nan"` and would otherwise be minted as a real
entity, so it is filtered explicitly. And `parent_name` is deliberately not a
fallback source — on an instance row it holds the parent model's *title*, not
its owner, so using it would create entities like "Phi-3" as if they were
people.

### `metrics` removed

Dropped from both models and instances. It held platform counters (votes,
downloads, instance count, version) that no downstream consumer reads, and
`build_model_triples` does not map the field, so nothing in it reached the
graph.

### Instance display names

An instance whose slug is generic — `default`, `1`, or empty, which covers
every single-variation model — now takes its name from the parent title plus
framework: `Simple CNN (PyTorch)` rather than one of forty identical
`default` entries. Real variation names like `phi-3.5-mini-instruct` pass
through untouched, and the original slug is preserved in the `slug` field.

### Framework name normalization

Kaggle reports the framework inconsistently across records — `pyTorch`,
`keras`, and `MODEL_FRAMEWORK_TENSOR_FLOW_2` all appear — while the instance
URL always carries the display form. `models_client` now writes a `frameworks`
array read from those URLs, so `PyTorch`, `Keras`, and `TensorFlow2` each
resolve to a single entity instead of several spellings of the same one.

The same normalization applies when reconstructing base-model references,
where `baseModelInstanceInformation` uses the field spelling: without it the
minted IRI would not match the instance it points at.

### Multi-valued license handling

License belongs to the instance, and one model can carry instances under
different licenses. `models_client` was joining them into a single display
string, so `"MIT, Apache 2.0"` would have been identified as one license.
It now also writes a `licenses` array, which the identifier reads. Splitting
the display string on a comma is deliberately avoided — license names
legitimately contain punctuation, e.g.
`Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)`.

[mlmodels.json](https://github.com/user-attachments/files/31298879/mlmodels.json)

