### PR TITLE
Temp/entity overview and timestamp fixes

### DIFF
--- a/api/routers/graph.py
+++ b/api/routers/graph.py
@@ -256,35 +256,53 @@ async def get_models_by_entity_uri(
         ...,
         description="The full entity URI to find related models for "
         "(e.g. 'https://w3id.org/mlentory/mlentory_graph/<entity-id>')",
-    )
+    ),
+    limit: Optional[int] = Query(
+        None,
+        ge=1,
+        le=500,
+        description="Max number of models to return (omit for all remaining after offset)",
+    ),
+    offset: int = Query(
+        0,
+        ge=0,
+        description="Number of models to skip for pagination",
+    ),
 ) -> RelatedModelsResponse:
     """
-    📋 Get all models related to an entity.
-    
-    Retrieves all ML models that are connected to the given entity URI via any relationship.
-    
+    Get models related to an entity (optionally paginated).
+
+    Retrieves ML models connected to the given entity URI. When ``limit`` is set,
+    only that page is returned; ``count`` is always the total match count.
+
     **Parameters:**
     - `entity_uri`: The entity URI to find related models for
-    
+    - `limit`: Optional page size
+    - `offset`: Optional page offset
+
     **Response:**
     - `entity_uri`: The queried entity URI
     - `models`: List of related models with properties and relationship types
-    - `count`: Total number of related models
+    - `count`: Total number of related models (not just this page)
 
     **Example:**
     ```
-    GET /api/v1/entities/related_models?entity_uri=https://w3id.org/mlentory/mlentory_graph/fd5b71...
+    GET /api/v1/graph/entities/related_models?entity_uri=https://w3id.org/mlentory/mlentory_graph/fd5b71...&limit=10&offset=0
     ```
     """
     try:
-        models = graph_service.get_models_by_entity_uri(entity_uri=entity_uri)
-        
+        models, total_count = graph_service.get_models_by_entity_uri(
+            entity_uri=entity_uri,
+            limit=limit,
+            offset=offset,
+        )
+
         return RelatedModelsResponse(
             entity_uri=entity_uri,
             models=models,
-            count=len(models)
+            count=total_count,
         )
-    
+
     except Exception as e:
         logger.error(f"Error getting models for entity URI: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/api/services/graph_service.py
+++ b/api/services/graph_service.py
@@ -612,29 +612,90 @@ class GraphService:
             return None
 
 
-    def get_models_by_entity_uri(self, entity_uri: str) -> List[Dict[str, Any]]:
+    # Outgoing relationships needed to render related-model cards without
+    # a follow-up full model-detail request per card.
+    _RELATED_MODEL_CARD_RELS = [
+        "schema__license",
+        "fair4ml__mlTask",
+        "schema__keywords",
+        "fair4ml__sharedBy",
+        "schema__author",
+    ]
+
+    def get_models_by_entity_uri(
+        self,
+        entity_uri: str,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> Tuple[List[Dict[str, Any]], int]:
         """
-        Get all models related to an entity URI.
-        
+        Get models related to an entity URI, optionally paginated.
+
+        Includes card-relevant outgoing relations (license, mlTask, keywords,
+        sharedBy/author) in the same Neo4j round-trip so callers do not need
+        N follow-up model-detail requests.
+
         Args:
             entity_uri: The entity URI to find related models for
-            
+            limit: Max models to return (None = all remaining after offset)
+            offset: Number of models to skip
+
         Returns:
-            List of dictionaries containing model information and relationship types
+            Tuple of (models list, total matching model count)
         """
-        query = """
+        if offset < 0:
+            offset = 0
+        if limit is not None and limit < 0:
+            limit = None
+
+        count_query = """
         MATCH (e {uri: $entityURI})
         MATCH (m:fair4ml__MLModel)-[r]-(e)
-        RETURN DISTINCT 
-            m.uri as model_uri,
-            m.schema__name as model_name,
-            type(r) as relationship_type,
-            properties(m) as model_properties
-        ORDER BY m.schema__name
+        RETURN count(DISTINCT m) AS count
         """
-        
+
+        # Paginate distinct models, then attach card relations in one query.
+        data_query = """
+        MATCH (e {uri: $entityURI})
+        MATCH (m:fair4ml__MLModel)-[r]-(e)
+        WITH m, collect(DISTINCT type(r))[0] AS relationship_type
+        ORDER BY coalesce(m.schema__name, m.uri)
+        SKIP $offset
+        """
+        if limit is not None:
+            data_query += "\nLIMIT $limit"
+
+        data_query += """
+        OPTIONAL MATCH (m)-[out]->(t)
+        WHERE type(out) IN $cardRels
+        RETURN
+            m.uri AS model_uri,
+            m.schema__name AS model_name,
+            relationship_type,
+            properties(m) AS model_properties,
+            collect(DISTINCT {
+                type: type(out),
+                target: coalesce(t.uri, t.schema__name)
+            }) AS relations
+        ORDER BY coalesce(m.schema__name, m.uri)
+        """
+
+        params: Dict[str, Any] = {
+            "entityURI": entity_uri,
+            "offset": int(offset),
+            "cardRels": self._RELATED_MODEL_CARD_RELS,
+        }
+        if limit is not None:
+            params["limit"] = int(limit)
+
         try:
-            results = _run_cypher(query, {"entityURI": entity_uri}, self.config)
+            count_rows = _run_cypher(count_query, {"entityURI": entity_uri}, self.config)
+            total_count = int(count_rows[0].get("count", 0)) if count_rows else 0
+
+            if total_count == 0:
+                return [], 0
+
+            results = _run_cypher(data_query, params, self.config)
 
             models: List[Dict[str, Any]] = []
             for record in results:
@@ -652,6 +713,30 @@ class GraphService:
                     else:
                         normalized_props[key] = str(value)
 
+                # Fold card relations into model_properties (same shape as node props)
+                for rel in record.get("relations") or []:
+                    if not isinstance(rel, dict):
+                        continue
+                    rel_type = rel.get("type")
+                    target = rel.get("target")
+                    if not rel_type or target is None:
+                        continue
+                    existing = normalized_props.get(rel_type)
+                    if existing is None:
+                        normalized_props[rel_type] = [str(target)]
+                    elif isinstance(existing, list):
+                        target_str = str(target)
+                        if target_str not in existing:
+                            existing.append(target_str)
+                    else:
+                        existing_str = str(existing)
+                        target_str = str(target)
+                        normalized_props[rel_type] = (
+                            [existing_str, target_str]
+                            if existing_str != target_str
+                            else [existing_str]
+                        )
+
                 models.append(
                     {
                         "model_uri": record.get("model_uri"),
@@ -661,13 +746,13 @@ class GraphService:
                     }
                 )
 
-            return models
+            return models, total_count
         except Exception as e:
             logger.error(
                 f"Error getting models for entity URI '{entity_uri}': {e}",
                 exc_info=True,
             )
-            return []
+            return [], 0
 
     def grouped_facet_values(self, entity_type: List[str]) -> Tuple[Dict[str, List[str]], int]:
         """

--- a/etl_extractors/hf/clients/models_client.py
+++ b/etl_extractors/hf/clients/models_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional, List, Dict
-from datetime import datetime
+from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pandas as pd
@@ -36,19 +36,34 @@ class HFModelsClient:
             logger.info("Loading models from HuggingFace dataset")
             dataset = load_dataset(
                 "librarian-bots/model_cards_with_metadata",
-                revision="4e7edd391342ee5c182afd08a6f62bff38f44535",
+                revision="4e8142ec7e7a3fa66db67b0119eebdc0092cd67d",
             )["train"].to_pandas()
 
             logger.info("Loaded %s models from the dataset", len(dataset))
 
+            # Normalize timestamps: upstream parquet may store last_modified as strings.
+            if "last_modified" in dataset.columns:
+                dataset["last_modified"] = pd.to_datetime(
+                    dataset["last_modified"], utc=True, errors="coerce"
+                )
+
             if update_recent:
                 latest_modification = dataset["last_modified"].max()
-                recent_models = self.get_recent_models_metadata(
-                    limit, latest_modification, threads
-                )
-                dataset = pd.concat([dataset, recent_models], ignore_index=True)
-                if "modelId" in dataset.columns:
-                    dataset = dataset.drop_duplicates(subset=["modelId"], keep="last")
+                if pd.isna(latest_modification):
+                    logger.warning(
+                        "Could not determine latest modification time; skipping update_recent"
+                    )
+                else:
+                    recent_models = self.get_recent_models_metadata(
+                        limit, latest_modification.to_pydatetime(), threads
+                    )
+                    dataset = pd.concat([dataset, recent_models], ignore_index=True)
+                    if "modelId" in dataset.columns:
+                        dataset = dataset.drop_duplicates(subset=["modelId"], keep="last")
+                    if "last_modified" in dataset.columns:
+                        dataset["last_modified"] = pd.to_datetime(
+                            dataset["last_modified"], utc=True, errors="coerce"
+                        )
 
             # Always sort by last modification time when available so that
             # pagination via ``offset`` is deterministic.
@@ -81,7 +96,13 @@ class HFModelsClient:
         models = self.api.list_models(limit=limit, sort="lastModified", direction=-1, full=True)
 
         def process_model(model):
-            if model.last_modified <= latest_modification:
+            model_modified = model.last_modified
+            if model_modified is not None and getattr(model_modified, "tzinfo", None) is None:
+                model_modified = model_modified.replace(tzinfo=timezone.utc)
+            cutoff = latest_modification
+            if cutoff is not None and getattr(cutoff, "tzinfo", None) is None:
+                cutoff = cutoff.replace(tzinfo=timezone.utc)
+            if model_modified is None or cutoff is None or model_modified <= cutoff:
                 return None
             try:
                 card = ModelCard.load(model.modelId, token=self.token) if self.token else ModelCard.load(

--- a/mcp_api/tools.py
+++ b/mcp_api/tools.py
@@ -431,21 +431,23 @@ def get_related_models_by_entity(
             return {
                 "error": f"Entity not found: {entity_name}",
             }
-        result = graph_service.get_models_by_entity_uri(entity_uri=result["uri"])
-        
+        models, total_count = graph_service.get_models_by_entity_uri(
+            entity_uri=result["uri"]
+        )
+
         # Transform results to only include requested fields
         transformed_models = []
-        for model in result:
+        for model in models:
             model_properties = model.get("model_properties", {})
             transformed_models.append({
                 "model_name": model.get("model_name") or model_properties.get("schema__name", ""),
                 "model_description": model_properties.get("schema__description", ""),
                 "shared_by": model_properties.get("fair4ml__sharedBy", ""),
             })
-        
+
         return {
             "models": transformed_models,
-            "count": len(transformed_models),
+            "count": total_count,
         }
     except Exception as e:
         logger.error(f"Error getting related models by entity: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- Paginate related-models and return card fields (license, task, keywords, author) in one Neo4j query so Entity Overview does not N+1 fetch each model.
- Normalize Hugging Face `last_modified` timestamps to UTC so `update_recent` does not fail on naive vs aware datetime comparisons.
